### PR TITLE
operationsClient's removeCompletedOperations doesn't work

### DIFF
--- a/bundles/org.eclipse.orion.client.core/web/orion/operationsClient.js
+++ b/bundles/org.eclipse.orion.client.core/web/orion/operationsClient.js
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * @license
- * Copyright (c) 2011, 2014 IBM Corporation and others.
+ * Copyright (c) 2011, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0
  * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution
@@ -120,7 +120,9 @@ define(['i18n!orion/operations/nls/messages', "orion/Deferred"], function(messag
                                     }
                                 }
                             }
-                            that._preferenceService.put(NAMESPACE, globalOperations).then(def.resolve, def.reject);
+                            // overriding the preference key's value completely so set it to clear
+                            var options = { clear: true };
+                            that._preferenceService.put(NAMESPACE, globalOperations, options).then(def.resolve, def.reject);
                         });
                     };
                 }(def), function(def) {

--- a/bundles/org.eclipse.orion.client.ui/web/js-tests/ui/operations/operationsClientTests.js
+++ b/bundles/org.eclipse.orion.client.ui/web/js-tests/ui/operations/operationsClientTests.js
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * @license
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html).
+ *
+ * Contributors: IBM Corporation - initial API and implementation
+ * 				 Google Inc. - Casey Flynn (caseyflynn@google.com)
+ ******************************************************************************/
+/*eslint-env browser, amd, mocha*/
+define([
+	"chai/chai",
+	"orion/bootstrap",
+	'orion/serviceregistry',
+	"orion/operationsClient",
+	"orion/progress",
+	"mocha/mocha"
+], function(chai, mBootstrap, mServiceRegistry, mOperationsClient, mProgress) {
+	var assert = chai.assert;
+
+	describe("Operations Client", function() {
+		it("Bug 510646", function(finished) {
+			mBootstrap.startup().then(function(core) {
+				var serviceRegistry = core.serviceRegistry;
+				var operationsClient = new mOperationsClient.OperationsClient(serviceRegistry);
+				var progressService = new mProgress.ProgressService(serviceRegistry, operationsClient);
+				var operation = {};
+				operation.Location = "/task/temp/bug510646";
+				operation.expires = 0;
+				operation.Name = "test";
+				operation.progressMonitor = {};
+				operation.progressMonitor.progress = function() {};
+				progressService.writeOperation(0, operation);
+				return operationsClient.removeCompletedOperations()
+				.then(function() {
+					return operationsClient.getOperations();
+				})
+				.then(function(operations) {
+					assert.equal(Object.keys(operations).length, 0);
+					finished();
+				});
+			})
+		});
+	});
+});

--- a/bundles/org.eclipse.orion.client.ui/web/js-tests/ui/uiTests.html
+++ b/bundles/org.eclipse.orion.client.ui/web/js-tests/ui/uiTests.html
@@ -32,6 +32,7 @@
 			"js-tests/ui/globalSearch/globalSearchTests",
 			"js-tests/ui/HTMLTemplates/HTMLTemplateTests",
 			"js-tests/ui/objects/objectsTests",
+			"js-tests/ui/operations/operationsClientTests",
 			"js-tests/ui/pageUtil/pageUtilTests",
 			"js-tests/ui/searchCrawler/searchCrawlerTests",
 			"js-tests/ui/settings/settingsTests",


### PR DESCRIPTION
`operationsClient`'s `removeCompletedOperations` doesn't actually remove the completed operations when the [call](https://github.com/rcjsuen/orion.client/blob/bd81ddb78e9317c99503f8892195e7fffb4f1752/bundles/org.eclipse.orion.client.core/web/orion/operationsClient.js#L123) is made to the preferences service. This is because it [checks](https://github.com/eclipse/orion.client/blob/6811b5a95ee231658a8446eab4e81a23dd96cc87/bundles/org.eclipse.orion.client.core/web/orion/preferences.js#L381-L385) for a `clear` defined on the `options` to determine whether the original preference's value should be merged with the passed in value or not.

In our case, the operations list gets parsed and completed entries gets removed. Then it gets to the preferences service and the removed entries gets added back in because it believes that only the passed in values should be modified and any values that aren't passed in should just be preserved. This makes sense when thinking of preferences in the regular way but fails in the `removeCompletedOperations` case so the fix is to send in `{ clear: true }` as an option when trying to remove the completed operations.

Note that this pull request is technically incomplete as the test doesn't seem to fail. When I comment out the fix, the test will just timeout instead of failing. The error that the assertion throws seems to get swallowed somewhere. Can someone with some knowledge about our `Deferred` implementation take a look at this?