### PR TITLE
A group of Theming Colour bugs fixing

### DIFF
--- a/bundles/org.eclipse.orion.client.editor/web/examples/js-demo.js
+++ b/bundles/org.eclipse.orion.client.editor/web/examples/js-demo.js
@@ -1,27 +1,21 @@
-var crypto = require('crypto');
-
 var hello = "hello";
 var foo = 123; // line comment
 /**
  * Test function.
- * <p>
- * receives three paremeters
- * </p>
+ * <p>receives three parameters</p>
  *
  * @param {Number} one
  * @param {Number} two
  * @param {Object} three
- * 
- * @see Tester
 */
 function testing(one, two, three) {
+	var crypto = require('crypto');
 	var bool = true;
 	this.service.junk("command", 4, bool, foo, hello);
+	errorVariable = 4;
 	return one + two + three;
 	console.log("Unreachable code");
 }
-// TODO 
-testing();
 
 for (var i = 0; i < 10; i++) {
 	foo += i;
@@ -30,10 +24,4 @@ for (var i = 0; i < 10; i++) {
 while (foo < 200) {
 	foo++;
 }
-
-try {
-	// do something
-} catch (e) {
-	// do more
-}
-errorVariable = 4;
+// TODO 

--- a/bundles/org.eclipse.orion.client.ui/web/css/controls.css
+++ b/bundles/org.eclipse.orion.client.ui/web/css/controls.css
@@ -1513,6 +1513,7 @@ html[dir="rtl"] .progressBarWrapper { /* ACGC */
 	text-overflow: ellipsis;
 	vertical-align: middle;
 	white-space: nowrap;
+	color: white;
 }
 
 .progressBarWrapper .progressBar {

--- a/bundles/org.eclipse.orion.client.ui/web/css/lightPage.css
+++ b/bundles/org.eclipse.orion.client.ui/web/css/lightPage.css
@@ -284,6 +284,10 @@
 	border-width: 4px;
 }
 
+.lightPage .uploadNodeText{
+	color: black;
+}
+
 @-webkit-keyframes rotateThis {
 	0% {
 		transform: rotate(0deg);

--- a/bundles/org.eclipse.orion.client.ui/web/css/theme_common.css
+++ b/bundles/org.eclipse.orion.client.ui/web/css/theme_common.css
@@ -663,6 +663,10 @@ a.breadcrumb.currentLocation {
 	color: #00AED1 !important;
 }
 
+.orionPage .findOptionsDiv .dropdownTrigger:not(.dropdownDefaultButton) {
+	color: white !important;
+}
+
 .desktopmode .dropdownTrigger a {
 	text-decoration: none;
 	pointer-events: none;
@@ -1196,8 +1200,8 @@ a.breadcrumb.currentLocation {
 }
 
 .contentassist .selected {
-	background-color: #1BB199 !important;
-	background: #1BB199 !important;
+	background-color: #1BB199;
+	background: #1BB199;
 	border-radius: 0; 
 	color: #FFF;
 }

--- a/bundles/org.eclipse.orion.client.ui/web/orion/widgets/themes/container/ContainerScopeList.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/widgets/themes/container/ContainerScopeList.js
@@ -106,6 +106,8 @@ define(['i18n!orion/settings/nls/messages'
 				"styles .editorTabCloseButton:hover background-color",
 				"styles .editorTab border-top",
 				"styles .editorTab border-right",
+				"styles .textviewTooltip .commandButton:not(.primaryButton):hover background-color", //.25 opcacity
+				"styles .textviewTooltip .commandButton:not(.primaryButton):focus background-color" //.25 opcacity
 			],
 			id: "tertiaryBackgroundColor",
 			value: defaultColor
@@ -188,7 +190,9 @@ define(['i18n!orion/settings/nls/messages'
 				"styles .treeTableRow span.core-sprite-closedarrow:hover color",
 				"styles .treeTableRow span.core-sprite-openarrow:hover color",
 				"styles .desktopmode .selectableNavRow:hover background-color", //.25 opcacity
-				"styles .editorTabCloseButton:hover background-color"
+				"styles .editorTabCloseButton:hover background-color",
+				"styles .contentassist .selected background-color",
+				"styles .textviewTooltip background-color"
 			],
 			id: "flavorColor",
 			value: defaultColor

--- a/bundles/org.eclipse.orion.client.ui/web/orion/widgets/themes/container/LightPage.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/widgets/themes/container/LightPage.js
@@ -240,10 +240,6 @@ define({
 				"border-color": "rgb(60, 113, 179)"
 			}
 		},
-		".editorTabCloseButton:hover": {
-			"background-color": "rgba(60, 113, 179, 1)",
-			"color": "#FFFFFF"
-		},
 		".projectNavColumn": {
 			"color": "#000000"
 		},
@@ -361,7 +357,16 @@ define({
 				"color": "white",
 				"margin-bottom": "2px"
 			},
-			"color": "#FFFFFF"
+			"color": "#FFFFFF",
+			"background-color": "rgb(60, 113, 179)",
+			".commandButton:not(.primaryButton):hover":{
+				"color": "white",
+   				"background-color": "rgba(196, 197, 200, 0.25)"
+			},
+			".commandButton:not(.primaryButton):focus":{
+				"color": "white",
+   				"background-color": "rgba(196, 197, 200, 0.25)"
+			}
 		},
 		".titleActionContainer": {
 			"background": "#F5F7FA !important",
@@ -416,10 +421,22 @@ define({
 		},
 		".treeTableRow": {
 			"span.core-sprite-closedarrow:hover" : {
-				"color": "#3C71B3"
+				"color": "#707070",
+				"background-color": "#A5B5BC"
 			},
 			"span.core-sprite-openarrow:hover" : {
-				"color": "#3C71B3"
+				"color": "#707070",
+				"background-color": "#A5B5BC"
+			}
+		},
+		".treeTableRow.checkedRow": {
+			"span.core-sprite-closedarrow:hover" : {
+				"color": "white",
+				"background-color": "#A5B5BC"
+			},
+			"span.core-sprite-openarrow:hover" : {
+				"color": "white",
+				"background-color": "#A5B5BC"
 			}
 		},
 		".workingTarget": {
@@ -443,7 +460,7 @@ define({
 			}
 		},
 		".editorTabCloseButton:hover": {
-			"background-color": "#3D72B3",
+			"background-color": "rgba(60, 113, 179, 1)",
 			"color": "#FFFFFF"
 		},
 		".editorTab": {
@@ -453,6 +470,10 @@ define({
 		".focusedEditorTab": {
 			"background-color": "#FFFFFF",
 			"color": "#152935"
+		},
+		".contentassist .selected":{
+			"background-color": "#3C71B3",
+			"background": "#3C71B3"
 		}
 	}
 });

--- a/bundles/org.eclipse.orion.client.ui/web/orion/widgets/themes/container/OrionPage.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/widgets/themes/container/OrionPage.js
@@ -33,7 +33,7 @@ define({
 			"background-color": "#1BB199 !important",
 			"color": "#FFFFFF !important",
 			".commandButton": {
-				"border-color": "#26343F",
+				"border-color": "white",
 				"color": "#FFFFFF"
 			},
 			".commandButton:not(.primaryButton):focus": {
@@ -62,7 +62,6 @@ define({
 		".checkedRow>td>span>a":{
 			"color": "#FFFFFF !important"
 		},
-
 		".commandButton": {
 			"background-color": "rgba(0, 0, 0, 0)",
 			"border-width": "1px",
@@ -356,12 +355,21 @@ define({
 		".textviewTooltip": {
 			".commandButton": {
 				"background-color": "inherit",
-				"border": "1px solid #325C80",
-				"border-color": "#26343F",
+				"border": "1px solid white",
+				"border-color": "white",
 				"color": "white",
 				"margin-bottom": "2px"
 			},
-			"color": "#FFFFFF"
+			"color": "#FFFFFF",
+			"background-color": "rgb(27, 177, 153)",
+			".commandButton:not(.primaryButton):hover":{
+				"color": "white",
+    			"background-color": "rgba(59, 75, 84,0.25)"
+			},
+			".commandButton:not(.primaryButton):focus":{
+				"color": "white",
+    			"background-color": "rgba(59, 75, 84,0.25)"			
+    		}
 		},
 		".titleActionContainer": {
 			"background": "#3B4B54 !important",
@@ -416,10 +424,22 @@ define({
 		},
 		".treeTableRow": {
 			"span.core-sprite-closedarrow:hover" : {
-				"color": "#1BB199"
+				"color": "#707070",
+				"background-color": "#A5B5BC"
 			},
 			"span.core-sprite-openarrow:hover" : {
-				"color": "#1BB199"
+				"color": "#707070",
+				"background-color": "#A5B5BC"
+			}
+		},
+		".treeTableRow.checkedRow": {
+			"span.core-sprite-closedarrow:hover" : {
+				"color": "white",
+				"background-color": "#A5B5BC"
+			},
+			"span.core-sprite-openarrow:hover" : {
+				"color": "white",
+				"background-color": "#A5B5BC"
 			}
 		},
 		".workingTarget": {
@@ -453,6 +473,10 @@ define({
 		".focusedEditorTab": {
 			"background-color": "#26343F",
 			"color": "#FFFFFF"
+		},
+		".contentassist .selected":{
+			"background-color": "#1BB199",
+			"background": "#1BB199"
 		}
 	}
 });

--- a/bundles/org.eclipse.orion.client.ui/web/orion/widgets/themes/editor/editorSetup.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/widgets/themes/editor/editorSetup.js
@@ -69,15 +69,15 @@ define([
 		var AT = mAnnotations.AnnotationType;
 		if(lang === "js"){
 			var annotationModel = editor.getAnnotationModel();
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_INFO, 4, 10, "Variable 'crypto' shadows a global member."));
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_ERROR, 381, 413, "Unreachable code"));
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_WARNING, 564, 577, "errorVariable' is undefined."));
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_DIFF_MODIFIED, 190, 225));
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_DIFF_ADDED, 450, 470));
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_DIFF_DELETED, 140, 141));
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_BLAME, 515, 530, "Theme editing feature commit 1"));
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_BLAME, 550, 551, "Theme editing feature commit 2"));
-	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_CURRENT_BLAME, 550, 551, ""));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_INFO, 228, 234, "Variable 'crypto' shadows a global member."));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_ERROR, 374, 406, "Unreachable code"));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_WARNING, 327, 340, "errorVariable' is undefined."));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_DIFF_MODIFIED, 160, 161));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_DIFF_ADDED, 130, 131));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_DIFF_DELETED, 70, 71));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_BLAME, 450, 451, "Theme editing feature commit 1"));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_BLAME, 480, 481, "Theme editing feature commit 2"));
+	 		annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_CURRENT_BLAME, 480, 481, ""));
 		}else if(lang === "css"){
 			var annotationModel = editor.getAnnotationModel();
 			annotationModel.addAnnotation(AT.createAnnotation(AT.ANNOTATION_INFO, 225, 232, "Duplicate property 'display' found."));


### PR DESCRIPTION
Bug 513482 - [Themes] A few Orion Font Icon's onhover colour is bad if it's parent's background is dark blue
Bug 513279 - Focused QuickFix button text is hard to read
Bug 499571 - folder name almost invisible during import
Bug 509233 - Fix a dark label in the light theme
Bug 514145 - [theme] The content assist selected colour is green in the light theme

Also modified js-demo and added textviewtooltip backgound color and content assist selected colour to "Flovor Color" category of IDE theming


Change-Id: Id82bbdd88a1dc2f9c4e26c16edef3a0b20e56121
Signed-off-by: Sidney <xinyij@ca.ibm.com>