### PR TITLE
Bug 517440 - Selection Color in Compare Editor is wrong

### DIFF
--- a/bundles/org.eclipse.orion.client.editor/web/orion/editor/textview.css
+++ b/bundles/org.eclipse.orion.client.editor/web/orion/editor/textview.css
@@ -8,13 +8,13 @@
 }
 
 .textviewSelection {
-	background: rgb(180, 213, 255);
+	background: rgba(180, 213, 255, 0.99);
 }
 .textviewContent ::-moz-selection {
-	background: rgb(180, 213, 255);
+	background: rgba(180, 213, 255, 0.99);
 }
 .textviewContent ::selection {
-	background: rgb(180, 213, 255);
+	background: rgba(180, 213, 255, 0.99);
 }
 .textviewSelectionUnfocused {
 	background: lightgray;


### PR DESCRIPTION
Change-Id: I85e52a62e34f69c302d5aae34c9a0a61e5d7dc78
Signed-off-by: Sidney <xinyij@ca.ibm.com>