### PR TITLE
Fix test failure introduced in Bug 517386 - Use Global Config's user.…

### DIFF
--- a/modules/orionode/lib/git/config.js
+++ b/modules/orionode/lib/git/config.js
@@ -86,7 +86,7 @@ function getConfig(req, res) {
 				return writeError(400, res, err.message);
 			}
 			var waitFor = Promise.resolve();
-			if(options.options.configParams["orion.single.user"]){
+			if(options && options.options && options.options.configParams["orion.single.user"]){
 				var user = config.user || (config.user = {});
 				if(!user.name){
 					waitFor = git.Config.openDefault().then(function(defaultConfig){


### PR DESCRIPTION
…name and user.email for the Local config.

Change-Id: Ifbcd462a8466ae681bd4e47105522b0e8c21abd4
Signed-off-by: Sidney <xinyij@ca.ibm.com>