### PR TITLE
LSP prevents Orion from opening files without a known content type

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/lsp/languageServerRegistry.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/lsp/languageServerRegistry.js
@@ -86,6 +86,9 @@ define([
 			 * @returns {LanguageServer} A language server impl - if one is mapped
 			 */
 			function getServerByContentType(contentType) {
+				if (!contentType) {
+					return null;
+				}
 				this.init();
 				var value = _contentTypes.get(contentType.id);
 				return value ? value : null;


### PR DESCRIPTION
1. Have some random ol' `.project` or `.classpath` Eclipse metadata file in your Orion workspace.
2. Launch the java-lsp Node server.

```
$ node modules/orionode/server.js -w /blah/blah/blah
```

3. Open Orion in your browser.
4. Try to open your `.project` or `.classpath` file.
5. You'll get exceptions in the browser console.

```
TypeError: Cannot read property 'id' of null
    at LanguageServerRegistry.getServerByContentType (http://localhost:8081/orion/lsp/languageServerRegistry.js:90:46)
    at MarkOccurrences.<anonymous> (http://localhost:8081/orion/markOccurrences.js:142:57)
    at http://localhost:8081/orion/EventTarget.js:42:8
    at Array.forEach (native)
    at EventTarget.dispatchEvent (http://localhost:8081/orion/EventTarget.js:39:15)
    at InputManager._setInputContents (http://localhost:8081/orion/inputManager.js:762:9)
    at InputManager.<anonymous> (http://localhost:8081/orion/inputManager.js:294:14)
    at settleDeferred (http://localhost:8081/orion/Deferred.js:70:28)
    at notify (http://localhost:8081/orion/Deferred.js:144:18)
    at MutationObserver.run (http://localhost:8081/orion/Deferred.js:28:13)
```