### PR TITLE
Windows backslashes make the LSP server unusable

### DIFF
--- a/modules/orionode/lib/languageServer.js
+++ b/modules/orionode/lib/languageServer.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials are made 
  * available under the terms of the Eclipse Public License v1.0 
  * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution 
@@ -257,6 +257,10 @@ exports.install = function(options) {
 					if (textDocument && textDocument.uri) {
 						var workspaceFile = fileUtil.getFile2(options.metastore, textDocument.uri.replace(/^\/file/, ''));
 						textDocument.uri = workspaceUrl + workspaceFile.path.slice(workspaceFile.workspaceDir.length);
+						// convert backslashes to slashes only if on Windows
+						if (path.sep === '\\') {
+							textDocument.uri = textDocument.uri.replace(/\\/g, "/");
+						}
 					}
 					var s = JSON.stringify(data);
 					if (!ready) {


### PR DESCRIPTION
1. Have a `../git/tmp/src/Test.java` structure.
2. Launch the java-lsp Node server.

```
$ node modules/orionode/server.js ../git
```

3. Open Orion in your browser.
4. Open your `Test.java` file.
5. Make some changes so that the LSP server starts. Wait for the Java LSP initialization to complete.
6. Make changes again to force document change events to be sent.

```
DidChangeTextDocumentParams [
  textDocument = VersionedTextDocumentIdentifier [
    version = 1
    uri = "file:///C:/Users/Remy/code/eclipse/git\tmp\Test.java"
  ]
  uri = null
  contentChanges = ArrayList (
    TextDocumentContentChangeEvent [
      range = Range [
        start = Position [
          line = 2
          character = 2
        ]
        end = Position [
          line = 2
          character = 2
        ]
      ]
      rangeLength = 0
      text = " "
    ]
  )
]
```

7. An exception will occur.

```
java.net.URISyntaxException: Illegal character in path at index 38: file:///C:/Users/Remy/code/eclipse/git\tmp\src\Test.java
	at java.net.URI$Parser.fail(URI.java:2848)
	at java.net.URI$Parser.checkChars(URI.java:3021)
	at java.net.URI$Parser.parseHierarchical(URI.java:3105)
	at java.net.URI$Parser.parse(URI.java:3053)
	at java.net.URI.<init>(URI.java:588)
	at org.eclipse.jdt.ls.core.internal.JDTUtils.toURI(JDTUtils.java:560)
	at org.eclipse.jdt.ls.core.internal.JDTUtils.resolveCompilationUnit(JDTUtils.java:105)
	at org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler.handleSaved(DocumentLifeCycleHandler.java:214)
	at org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler.access$3(DocumentLifeCycleHandler.java:211)
	at org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler$4.run(DocumentLifeCycleHandler.java:101)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2240)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2262)
	at org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler.didSave(DocumentLifeCycleHandler.java:98)
	at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.didSave(JDTLanguageServer.java:373)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:51)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.notify(GenericEndpoint.java:126)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleNotification(RemoteEndpoint.java:165)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:136)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:149)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:77)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:84)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```