### PR TITLE
Bug 518659 - Remove usages of includes() in explorer-table

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/explorers/explorer-table.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/explorers/explorer-table.js
@@ -183,7 +183,7 @@ define([
 		},
 		_isExpression: function(fileFilter) {
 			if (fileFilter) {
-				return (fileFilter.indexOf("*") !== -1) || (fileFilter.indexOf("?") !== -1);
+				return (fileFilter.indexOf("*") > -1) || (fileFilter.indexOf("?") > -1);
 			}
 			return false;
 		},

--- a/bundles/org.eclipse.orion.client.ui/web/orion/explorers/explorer-table.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/explorers/explorer-table.js
@@ -183,7 +183,7 @@ define([
 		},
 		_isExpression: function(fileFilter) {
 			if (fileFilter) {
-				return fileFilter.includes("*") || fileFilter.includes("?");
+				return (fileFilter.indexOf("*") !== -1) || (fileFilter.indexOf("?") !== -1);
 			}
 			return false;
 		},


### PR DESCRIPTION
Remove usages of ES6 includes.

Signed-off-by: Casey Flynn <caseyflynn@google.com>