### PR TITLE
fix a few node defects in together

### DIFF
--- a/modules/orionode/lib/user.js
+++ b/modules/orionode/lib/user.js
@@ -405,10 +405,16 @@ module.exports.router = function(options) {
 			}
 			if (options.configParams["orion.auth.user.creation.force.email"]) {
 				sendMail({user: user, options: options, template: CONFIRM_MAIL, auth: CONFIRM_MAIL_AUTH, req: req});
+				return api.writeResponse(201, res, null, {error: "Created"});
 			} else {
-				user.isAuthenticated = true;	
+				user.isAuthenticated = true;
+				store.updateUser(user.username, user, function(err, user) {
+					if (err) {
+						return logError(err);
+					}
+					return api.writeResponse(201, res, null, {error: "Created"});
+				});
 			}
-			return api.writeResponse(201, res, null, {error: "Created"});
 		});
 	});
 

--- a/modules/orionode/orion.conf
+++ b/modules/orionode/orion.conf
@@ -31,31 +31,35 @@ orion.site.virtualHosts=*.local.orion.org
 #orion.https.key=
 #orion.https.cert=
 
-#context path
+# Context path
 orion.context.path=
 orion.context.listenPath=false
 
-# mail
+# Mail
 mail.smtp.host=smtp.gmail.com
 mail.smtp.port=465
 mail.smtp.user=swtbuild@gmail.com
 mail.smtp.password=
 mail.from=
 
-#serve these static assets before the original default ones(will overwrite if the path is match), relative to orion_static.js
+# Serve these static assets before the original default ones(will overwrite if the path is match), relative to orion_static.js
 prepend.static.assets=
 
-#serve these static assets after the original default ones(will not overwrite original ones, but might be overwritten), relative to orion_static.js
+# Serve these static assets after the original default ones(will not overwrite original ones, but might be overwritten), relative to orion_static.js
 append.static.assets=
 
-#defines where cf get bearer token from
+# Defines where cf get bearer token from
 cf.bearer.token.store=
 
-#specify the path of the json file which defines additional endpoints
+# Specify the path of the json file which defines additional endpoints
 additional.endpoint=
 
-#serve additional modules
+# Serve additional modules
 additional.modules.path=
 
-#shutdown timeout, wait for a period of time before force process exit
+# Shutdown timeout, wait for a period of time before force process exit
 shutdown.timeout=10000
+
+# MongoDB Setting
+orion.mongodb.url=mongodb://localhost/orion_multitenant
+orion.mongodb.cf=false


### PR DESCRIPTION
1: code to make sure the workspace dir is exist, or create one if not; need to make the call async enventually.
2: fix E11000 duplicat key error index: orion_multinenant.orionaccounts.$workspaces.id dup key:{:null} error, by adding sparse in workspaceSchema
3: add orion.mongodb.cf orion configuration to support the case where the mongodb database is a cf "compose-for-mongodb" service
4: add orion.mongodb.url orion configuration to support various mongodb url, by default it's the local one.
5: fix the defect where user.isAuthenticated = true not saved to database when "orion.auth.user.creation.force.email" is set to false in orion.conf

Signed-off-by: Sidney <xinyij@ca.ibm.com>