### PR TITLE
Bug 516574 - Exception in orion.eclipse.org (Error: Forbidden at getRepoByPath )

### DIFF
--- a/modules/orionode/lib/git/clone.js
+++ b/modules/orionode/lib/git/clone.js
@@ -107,19 +107,27 @@ function cloneJSON(base, location, giturl, parents, submodules) {
 	}
 	return result;
 }
-	
+
+/**
+ * @description Computes the root path to search in to try and find a git repository
+ * @param {String} filePath The full path to the file
+ * @param {String} workspaceDir The full path to the workspace root
+ * @returns {Promise} A promise to open a repository at the given location
+ */
 function getRepoByPath(filePath, workspaceDir) {
-	filePath = util.decodeURIComponent(filePath);
-	while (!fs.existsSync(filePath)) {
-		filePath = path.dirname(filePath);
-		if (filePath.length < workspaceDir.length) return Promise.reject(new Error("Forbidden"));
+	var fPath = util.decodeURIComponent(filePath);
+	while (!fs.existsSync(fPath)) {
+		fPath = path.dirname(fPath);
+		if (!fPath.startsWith(workspaceDir)) {
+			return Promise.reject(new Error("Forbidden - Access is denied to: "+fPath));
+		}
 	}
  	var ceiling = path.dirname(workspaceDir);
-	if (!fs.statSync(filePath).isDirectory()) {
+	if (!fs.statSync(fPath).isDirectory()) {
 		// get the parent folder if pointing at a file
-		filePath = path.dirname(filePath);
+		fPath = path.dirname(fPath);
 	}
-	return git.Repository.discover(filePath, 0, ceiling).then(function(buf) {
+	return git.Repository.discover(fPath, 0, ceiling).then(function(buf) {
 		return git.Repository.open(buf.toString());
 	});
 }	

--- a/modules/orionode/lib/git/util.js
+++ b/modules/orionode/lib/git/util.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials are made 
  * available under the terms of the Eclipse Public License v1.0 
  * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution 
@@ -16,6 +16,13 @@ module.exports.encodeURIComponent = function(path) {
 	return encodeURIComponent(encodeURIComponent(path));
 };
 
+/**
+ * @name module.exports.decodeURIComponent
+ * @description Helper to properly decode a path.
+ * @function
+ * @param {string} path The path to decode
+ * @returns {string} The decoded path
+ */
 module.exports.decodeURIComponent = function(path) {
 	var result = path;
 	try {


### PR DESCRIPTION
I could not reproduce the original exception - which was likely fixed with all the updates to check correct access for endpoints, but this fix does update some funky path length logic with a check to see if the requested file path is at least a child of the users workspace path.