### PR TITLE
Bug 522667 - CodeEdit: Reload Issue when using CodeEdit-Widget from Angular2.

### DIFF
--- a/bundles/org.eclipse.orion.client.javascript/web/javascript/javascriptProject.js
+++ b/bundles/org.eclipse.orion.client.javascript/web/javascript/javascriptProject.js
@@ -67,41 +67,35 @@ define([
 		 * @callback
 		 */
 		onCreated: function onCreated(project, qualifiedName, fileName) {
-			//We can read the new files and update here, but that could take longer than 
-			//would be ready for the next getComputedEnvironment call - just wipe the cache
-			//and recompute when asked for
-			if(project.importantChange(qualifiedName, fileName)) {
-				this._update(project);
-			}
+			this.setUpdateRequired(project, qualifiedName, fileName);
 		},
 		/**
 		 * @callback
 		 */
 		onDeleted: function onDeleted(project, qualifiedName, fileName) {
-			//We don't have access to the deleted contents - wipe the cache and recompute
-			if(project.importantChange(qualifiedName, fileName)) {
-				this._update(project);
-			}
+			this.setUpdateRequired(project, qualifiedName, fileName);
 		},
 		/**
 		 * @callback
 		 */
 		onModified: function onModified(project, qualifiedName, fileName) {
-			project.updateNeeded = project.importantChange(qualifiedName, fileName);
+			this.setUpdateRequired(project, qualifiedName, fileName);
 		},
 		/**
-		 * @name _wipeCache
-		 * @description Clears the 'env' cache if the file name is a project configuration-like file
+		 * @name setUpdateRequired
+		 * @description Sets the state of the computed environemnt to needing an update
 		 * @function
-		 * @private
-		 * @param {JavaScriptProject} project The backing project
+		 * @param {JavaScriptProject.prototype} project The backing project making the callback
+		 * @param {string} qualifiedName The fully qualified name of the file that has changed
+		 * @param {string} fileName The file name
+		 * @since 16.0
 		 */
-		_update: function _update(project) {
-			project.projectPromise = new Deferred();
-			return computeEnvironment(project, true).then(/* @callback */ function(env) {
-				project.projectPromise.resolve();
-			});
-		} 
+		setUpdateRequired: function setUpdateRequired(project, qualifiedName, fileName) {
+			var important = project.importantChange(qualifiedName, fileName);	
+			if(important) {
+				project.updateNeeded = true;
+			}
+		}
 	};
 	
 	var initialized = false;

--- a/modules/orionode/lib/workspace.js
+++ b/modules/orionode/lib/workspace.js
@@ -19,7 +19,7 @@ var express = require('express'),
 	responseTime = require('response-time');
 
 var writeError = api.writeError, 
-	writeResponse = api.writeRespons;
+	writeResponse = api.writeResponse;
 
 module.exports = function(options) {
 	var fileRoot = options.fileRoot;


### PR DESCRIPTION
This ensures the tooling will restart correctly in the code edit widget.

The changes:
1. in the environment handler, we stop pre-computing the environment - this was found to be unnecessary, and was part of the cause of the race condition

2. we only want to the set the flag 'updateNeeded' to true, not simply to the result of the call to importantChange. Since the code edit widget sends so many requests about files being created so quickly, the other part of the race condition was that this flag would get set to false before it was consulted - this resulted in the tooling setting its state to "needs a reset" but then never doing the reset since the env state was not also set to "needs update"