### PR TITLE
org-ids/web-ide-issues#702: get bitbucket repo information from toolc…

### DIFF
--- a/modules/orionode/lib/git/credentials.js
+++ b/modules/orionode/lib/git/credentials.js
@@ -14,8 +14,10 @@ var url = require('url');
 
 module.exports = {};
 
+var BITBUCKET = "bitbucket.org";
 var GITLAB = "gitlab.com";
 var OAUTH2 = "oauth2";
+var XTOKENAUTH = "x-token-auth";
 
 var tokenProviders = [];
 
@@ -50,7 +52,14 @@ module.exports.getCredentials = function(uri, user) {
 				function(result) {
 					if (++doneCount <= tokenProviders.length) {
 						doneCount = tokenProviders.length;
-						var username = url.parse(uri).host.toLowerCase() === GITLAB ? OAUTH2 : result;
+						var username = result; /* typical case */
+						var host = url.parse(uri).host.toLowerCase();
+						if (host === GITLAB) {
+							username = OAUTH2;
+						} else if (host === BITBUCKET) {
+							username = XTOKENAUTH;
+						}
+
 						fulfill(git.Cred.userpassPlaintextNew(username, result));
 					}
 				},


### PR DESCRIPTION
…hain

This is the node server implementation.  The token-feeding implementation already did not do any caching of tokens, so nothing special was needed to ensure we don't try to use an expired bitbucket token.

I'm not proud of our sniffing of the repo url host to detect the bitbucket and gitlab cases.  The consolidated broker recently began providing repo_type info, so after the Orion 16 release when changes can be a bit more aggressive I plan to improve this.
