### PR TITLE
Bug 526012 - openEditor should return a promise when called

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/editorView.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/editorView.js
@@ -625,7 +625,7 @@ define([
 			 * @since 9.0
 			 */
 			contextImpl.openEditor = function(fileurl, options) {
-				activateContext.openEditor(fileurl, options);
+				return activateContext.openEditor(fileurl, options);
 			};
 			
 			/**


### PR DESCRIPTION
Update setup to return a promise that resolves when openEditor
successfully changes input.

Update editorView to return said promise.

Signed-off-by: Casey Flynn <caseyflynn@google.com>