### PR TITLE
Distinguish prototypes/classes from functions in content assist

### DIFF
--- a/bundles/org.eclipse.orion.client.javascript/web/javascript/contentAssist/ternAssist.js
+++ b/bundles/org.eclipse.orion.client.javascript/web/javascript/contentAssist/ternAssist.js
@@ -260,7 +260,7 @@ define([
         proposal.name = proposal.proposal = completion.name;
         if(typeof completion.type !== 'undefined') {
             if(/^fn/.test(completion.type)) {
-            	proposal.tags = [{cssClass: 'iconFunction'}];
+            	proposal.tags = [{cssClass: /^[A-Z]/.test(proposal.name) ? 'iconClass' : 'iconFunction'}];
             	calculateFunctionProposal(completion, args, proposal);
             } else if(completion.type === 'template' || completion.type === 'jsdoc_template') {
             	var prefix = proposal.prefix;

--- a/bundles/org.eclipse.orion.client.javascript/web/js-tests/javascript/ternAssistTests.js
+++ b/bundles/org.eclipse.orion.client.javascript/web/js-tests/javascript/ternAssistTests.js
@@ -166,6 +166,12 @@ define([
 							assert.equal(offset, ep[3].offset, "Template proposal had different offset for selection group. Actual offset: " + offset + " Actual length: " + len);
 							assert.equal(len, ep[3].length, "Template proposal had different length for selection group. Actual offset: " + offset + " Actual length: " + len);						
 						}
+						if (ep.length >= 5) {
+							assert(ap.tags, "Expected proposal with tags");
+							assert(ap.tags[0], "Expected proposal to have at least one tag");
+							var cssClass = ep[4];
+							assert.equal(ap.tags[0].cssClass, cssClass, "Proposal had different cssClass. Actual cssClass: " + ap.tags[0].cssClass + "; Expected: " + cssClass);
+						}
 					}
 					worker.getTestState().callback();
 				}
@@ -5596,6 +5602,28 @@ define([
 					};
 					testProposals(options, [
 						['$_test', '$_test : number'],
+					]);
+				});
+			});
+			describe("PascalCase heuristic", function () {
+				it("Functions with PascalCase name get recognized as prototype/class", function(done) {
+					var options = {
+						buffer: "function Foo() {} Foo",
+						prefix: "Foo",
+						offset: 18,
+						callback: done};
+					return testProposals(options, [
+						["Foo()", "Foo()", "Foo()", undefined, "iconClass"]
+					]);
+				});
+				it("Functions with camelCase name get recognized as function", function(done) {
+					var options = {
+						buffer: "function foo() {} foo",
+						prefix: "foo",
+						offset: 18,
+						callback: done};
+					return testProposals(options, [
+						["foo()", "foo()", "foo()", undefined, "iconFunction"]
 					]);
 				});
 			});


### PR DESCRIPTION
This is just a suggestion, so feel free to discuss/merge/discard this pull request.

The icons in the content assist help distinguish the different types of completions available. However, prototypes/classes are displayed as functions (which they technically are) because Tern only has a syntax to declare functions.

Since most JavaScript libraries use the convention that prototypes/classes are written in PascalCase instead of camelCase, this can be used as a heuristic to distinguish prototypes/classes from functions in content assist.
