### PR TITLE
Add preferences to disable editor UI elements.

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/edit/setup.js
+++ b/bundles/org.eclipse.orion.client.ui/web/edit/setup.js
@@ -1658,7 +1658,7 @@ objects.mixin(EditorSetup.prototype, {
 		this.statusService = new mStatus.StatusReportingService(serviceRegistry, this.operationsClient, "statusPane", "notifications", "notificationArea"); //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$ //$NON-NLS-3$
 		this.commandRegistry = new mCommandRegistry.CommandRegistry({selection: this.selection});
 		this.dialogService = new mDialogs.DialogService(serviceRegistry, this.commandRegistry);
-		this.progressService = new mProgress.ProgressService(serviceRegistry, this.operationsClient, this.commandRegistry);
+		this.progressService = new mProgress.ProgressService(serviceRegistry, this.operationsClient, this.commandRegistry, null, this.preferences);
 		this.getGeneralPreferences().then(function() {
 			if (this.generalPreferences.enableDebugger) {
 				this.nativeDeployService = new mNativeDeployService.NativeDeployService(serviceRegistry, this.commandRegistry);
@@ -1745,27 +1745,33 @@ objects.mixin(EditorSetup.prototype, {
 	createRunBar: function () {
 		var menuBar = this.menuBar;
 		var runBarParent = menuBar.runBarNode;
-		return mCustomGlobalCommands.createRunBar({
-			parentNode: runBarParent,
-			serviceRegistry: this.serviceRegistry,
-			commandRegistry: this.commandRegistry,
-			fileClient: this.fileClient,
-			projectCommands: ProjectCommands,
-			projectClient: this.serviceRegistry.getService("orion.project.client"),
-			progressService: this.progressService,
-			preferences: this.preferences,
-			editorInputManager: this.editorInputManager,
-			generalPreferences: this.generalPreferences
-		}).then(function(runBar){
-			if (runBar) {
-				this.preferences.get('/runBar').then(function(prefs){ //$NON-NLS-1$
+		return this.preferences.get('/runbar').then(function(prefs) {
+			if (Boolean(prefs) && prefs.disabled === true) {
+				console.log('returning resolved promise.')
+				var d = new Deferred();
+				d.resolve();
+				return d;
+			}
+			return mCustomGlobalCommands.createRunBar({
+				parentNode: runBarParent,
+				serviceRegistry: this.serviceRegistry,
+				commandRegistry: this.commandRegistry,
+				fileClient: this.fileClient,
+				projectCommands: ProjectCommands,
+				projectClient: this.serviceRegistry.getService("orion.project.client"),
+				progressService: this.progressService,
+				preferences: this.preferences,
+				editorInputManager: this.editorInputManager,
+				generalPreferences: this.generalPreferences
+			}).then(function(runBar){
+				if (runBar) {
 					this.runBar = runBar;
 					var displayRunBar = prefs.display === undefined  || prefs.display;
-					 if (!displayRunBar) {
-					 	lib.node("runBarWrapper").style.display = "none";
-					 }
-				}.bind(this));
-			}
+					if (!displayRunBar) {
+						lib.node("runBarWrapper").style.display = "none";
+					}
+				}
+			}.bind(this));
 		}.bind(this));
 	},
 	

--- a/bundles/org.eclipse.orion.client.ui/web/orion/editorCommands.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/editorCommands.js
@@ -239,8 +239,13 @@ define([
 		},
 		registerCommands: function() {
 			var commandRegistry = this.commandService;
-			
-			commandRegistry.registerCommandContribution("settingsActions", "orion.edit.settings", 1, null, false, new mKeyBinding.KeyBinding("s", true, true), null, this); //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
+			if (this.preferences) {
+				this.preferences.get('/editorSettingsActions').then(function(prefs) {
+					if (!Boolean(prefs) || !Boolean(prefs.disabled)) {
+						commandRegistry.registerCommandContribution("settingsActions", "orion.edit.settings", 1, null, false, new mKeyBinding.KeyBinding("s", true, true), null, this); //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
+					}
+				}.bind(this));
+			}
 			commandRegistry.registerCommandContribution(this.editToolbarId || this.toolbarId, "orion.edit.undo", 400, this.editToolbarId ? "orion.menuBarEditGroup/orion.edit.undoGroup" : null, !this.editToolbarId, new mKeyBinding.KeyBinding('z', true), null, this); //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-3$
 			commandRegistry.registerCommandContribution(this.editToolbarId || this.toolbarId, "orion.edit.redo", 401, this.editToolbarId ? "orion.menuBarEditGroup/orion.edit.undoGroup" : null, !this.editToolbarId, util.isMac ? new mKeyBinding.KeyBinding('z', true, true) : new mKeyBinding.KeyBinding('y', true), null, this); //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-4$
 			commandRegistry.registerCommandContribution(this.saveToolbarId || this.toolbarId, "orion.edit.openFolder", 1, this.saveToolbarId ? "orion.menuBarFileGroup/orion.edit.saveGroup" : null, false, new mKeyBinding.KeyBinding('o', true)); //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$

--- a/bundles/org.eclipse.orion.client.ui/web/orion/progress.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/progress.js
@@ -10,39 +10,56 @@
  *******************************************************************************/
 /*eslint-env browser, amd*/
 define(['i18n!orion/nls/messages', 'orion/webui/littlelib', 'orion/webui/dialogs/OperationsDialog',
-	'orion/webui/tooltip',
+	'orion/webui/tooltip', 'orion/Deferred',
 ], 
-function(messages, lib, mOperationsDialog, Tooltip) {
+function(messages, lib, mOperationsDialog, Tooltip, Deferred) {
 	
-	function ProgressMonitorTool(progressPane, commandRegistry){
+	function ProgressMonitorTool(progressPane, commandRegistry, preferenceService){
 		if(this._progressPane){
 			return;
 		}
-		this._progressPane = lib.node(progressPane);
-
-		this._progressPane.tooltip = new Tooltip.Tooltip({
-			node: this._progressPane,
-			text: messages["Operations"],
-			position: ["above", "below", "right", "left"] //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
-		});
-
-		this._operationsDialog = new mOperationsDialog.OperationsDialog({triggerNode: this._progressPane, commandRegistry: commandRegistry});
-		var that = this;
-		this._progressPane.addEventListener("keydown", function(evt) {  //$NON-NLS-0$
-			if(evt.charOrCode === ' ' || evt.keyCode === lib.KEY.ENTER) { //$NON-NLS-0$
-				that._operationsDialog.show();
+		var prefDeferred = new Deferred();
+		if (Boolean(preferenceService)) {
+			preferenceService.get("/progressIndicator").then(function(prefs) {
+				prefDeferred.resolve(prefs);
+			});
+		} else {
+			prefDeferred.resolve();
+		}
+		prefDeferred.then(function(prefs) {
+			if (Boolean(prefs) && prefs.disabled === true) {
+				var pane = lib.node(progressPane);
+				if (Boolean(pane)) {
+					pane.parentElement.removeChild(pane);				
+				}
+				return;
 			}
-		});
-		
-		this._progressPane.addEventListener("click", /* @callback */ function(evt) {  //$NON-NLS-0$
-			if (that._operationsDialog.isShowing()) {
-				that._operationsDialog.hide();
-			} else {
-				that._operationsDialog.show();
-			}
-		});
-		
-		this._operationsDialog.setOperations(null, null); // initialize
+			this._progressPane = lib.node(progressPane);
+	
+			this._progressPane.tooltip = new Tooltip.Tooltip({
+				node: this._progressPane,
+				text: messages["Operations"],
+				position: ["above", "below", "right", "left"] //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
+			});
+	
+			this._operationsDialog = new mOperationsDialog.OperationsDialog({triggerNode: this._progressPane, commandRegistry: commandRegistry});
+			var that = this;
+			this._progressPane.addEventListener("keydown", function(evt) {  //$NON-NLS-0$
+				if(evt.charOrCode === ' ' || evt.keyCode === lib.KEY.ENTER) { //$NON-NLS-0$
+					that._operationsDialog.show();
+				}
+			});
+			
+			this._progressPane.addEventListener("click", /* @callback */ function(evt) {  //$NON-NLS-0$
+				if (that._operationsDialog.isShowing()) {
+					that._operationsDialog.hide();
+				} else {
+					that._operationsDialog.show();
+				}
+			});
+			
+			this._operationsDialog.setOperations(null, null); // initialize
+		}.bind(this));
 	}
 	
 	ProgressMonitorTool.prototype = {
@@ -134,7 +151,7 @@ function(messages, lib, mOperationsDialog, Tooltip) {
 	 * @param {orion.serviceregistry.ServiceRegistry} serviceRegistry
 	 * @param {orion.operationsclient.OperationsClient} operationsClient
 	 */
-	function ProgressService(serviceRegistry, operationsClient, commandRegistry, progressMonitorClass){
+	function ProgressService(serviceRegistry, operationsClient, commandRegistry, progressMonitorClass, preferenceService){
 		this._serviceRegistry = serviceRegistry;
 		this._serviceRegistration = serviceRegistry.registerService("orion.page.progress", this); //$NON-NLS-0$ 
 		this._commandRegistry = commandRegistry;
@@ -145,6 +162,8 @@ function(messages, lib, mOperationsDialog, Tooltip) {
 		this._lastOperation = null;
 		this._lastIconClass = null;
 		this._progressMonitorClass = progressMonitorClass;
+		this._preferenceService = preferenceService;
+		console.log(preferenceService)
 	}
 	
 	ProgressService.prototype = /** @lends orion.progress.ProgressService.prototype */ {
@@ -152,7 +171,7 @@ function(messages, lib, mOperationsDialog, Tooltip) {
 				if(this._progressMonitorClass){
 					return; // we have an other progress monitor implementation, we don't need to initialize our UI
 				}
-				this._progressMonitorTool = new ProgressMonitorTool(progressPane, this._commandRegistry);
+				this._progressMonitorTool = new ProgressMonitorTool(progressPane, this._commandRegistry, this._preferenceService);
 			},
 			progress: function(deferred, operationName, progressMonitor){
 				var that = this;


### PR DESCRIPTION
Add preferences that will disable specific elements of the editor ui:
RunBar
Editor Settings
User Menu
Progress Indicator

Driven by the following preferences (respectively):
"/runbar": {disabled: true}
"/editorSettingsActions": {disabled: true}
"/userMenu": {disabled: true}
"/progressIndicator": {disabled: true}

Signed-off-by: Casey Flynn <caseyflynn@google.com>