### PR TITLE
Provide file name if available when constructing href.

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/edit/setup.js
+++ b/bundles/org.eclipse.orion.client.ui/web/edit/setup.js
@@ -1899,7 +1899,7 @@ objects.mixin(EditorSetup.prototype, {
 	 * @since 9.0
 	 */
 	openEditor: function(loc, options) {
-		var href = this.computeNavigationHref({Location: loc}, {start: options.start, end: options.end});
+		var href = this.computeNavigationHref({Location: loc, Name: options.name}, {start: options.start, end: options.end});
 		var openEditorPromise = new Deferred();
 
 		if (!href) {


### PR DESCRIPTION
Provide the file name (if available) so the constructed path will open
the file with the correct editor.

Signed-off-by: Casey Flynn <caseyflynn@google.com>