### PR TITLE
Bug 531066 - Provide metastore implementation for orionhub.org

### DIFF
--- a/modules/orionode/lib/metastore/mongodb/store.js
+++ b/modules/orionode/lib/metastore/mongodb/store.js
@@ -248,7 +248,12 @@ Object.assign(MongoDbMetastore.prototype, {
 			if (err) {
 				return callback(err);
 			}
-			return callback(null, users);
+			let vals = users.slice(start, start+rows),
+				result = [];
+			vals.forEach((val) => {
+				result.push(val.username);
+			})
+			return callback(null, result);
 		});
 	},
 	getUser: function(id, callback) {
@@ -373,10 +378,6 @@ Object.assign(MongoDbMetastore.prototype, {
 			mongooseTask.expires = taskObj.expires;
 		}
 		mongooseTask.cancelable = Boolean(taskObj.cancelable);
-//		if (taskObj.uriUnequalStrategy) {
-//			mongooseTask.uriUnequalStrategy = taskObj.uriUnequalStrategy; // TODO needed?
-//		}
-
 		mongooseTask.save(callback);
 	}
 });

--- a/modules/orionode/lib/metastore/util/userIndex.js
+++ b/modules/orionode/lib/metastore/util/userIndex.js
@@ -13,247 +13,276 @@ const fs = require("fs"),
 	log4js = require('log4js'),
 	logger = log4js.getLogger("user-index");
 
-const UNAME_INDEX_NAME = ".unameIndex",
-	EMAIL_INDEX_NAME = ".emailIndex";
+const OAUTH_INDEX_NAME = ".oauthIndex",
+	EMAIL_INDEX_NAME = ".emailIndex",
+	UNAME_INDEX_NAME = ".userIndex";
 
-let _workspaceDir,
-	unameIndex,
-	emailIndex;
-
-/**
- * Creates a new user index. It is up to the backing metastore to initialize the index prior to its use.
- * @param {string} workspaceDir The root of the server workspace
- * @since 18.0
- */
-function UserIndex(workspaceDir) {
-	_workspaceDir = workspaceDir;
-	unameIndex = null;
-	emailIndex = null;
-}
-module.exports = UserIndex;
-
-Object.assign(UserIndex.prototype, {
+class UserIndex {
 	/**
-	 * Read or create the user name and email indexes. If the indexes do not exist, or there was some problem reading them
-	 * the user directories are re-scanned to ensure consistency
-	 * @returns {Promise} A promise to load the caches. Rejects if the caches could not be loaded
+	 * Creates a new user index. It is up to the backing metastore to initialize the index prior to its use.
+	 * @param {{?}} metastore The backing metastore for the index
+	 * @since 18.0
 	 */
-	getUserIndex: function getUserIndex() {
-		return new Promise(function(resolve, reject) {
-			if(unameIndex && emailIndex) {
-				return resolve();
-			}
-			return readIndexFiles().then(() => {
-				resolve();
-			}, function() { 
-				resolve(createIndex(this, _workspaceDir));
-			}.bind(this)) 
-		}.bind(this));
-	},
+	constructor(metastore) {
+		this._metastore = metastore;
+		this._workspaceDir = metastore._options.workspaceDir;
+		this.oauthIndex = null;
+		this.emailIndex = null;
+		this.userIndex = null;
+	}
 	/**
-	 * Returns if the index is ready for use
-	 * @returns true if the index has been initialized, false otherwise
-	 */
-	indexReady: function indexReady() {
-		return unameIndex && emailIndex;
-	},
-	/**
-	 * Looks up the user with the givem `userName` in the cache
+	 * Looks up the user with the given `userEmail` in the cache
+	 * @param {string} userEmail The email of the user we wish to look up
 	 * @returns {Promise} A promise that will resolve to null or the full filesystem path to query for the user metadata
 	 */
-	getUserByUname: function getUserByUname(userName) {
-		return new Promise(function(resolve, reject) {
-			if(this.indexReady()) {
-				return resolve(unameIndex.get(userName));
+	getUserByEmail(userEmail) {
+		return this.getUserIndex().then(function() {
+			const uname = emailIndex.get(userEmail);
+			if(uname) {
+				return new Promise(function(resolve, reject) {
+					this._metastore.getUser(uname, (err, userInfo) => {
+						if(err) {
+							return reject(err);
+						}
+						return resolve(userInfo);
+					});
+				});
 			}
-			resolve(null);
+			return null;
 		}.bind(this));
-	},
+	}
 	/**
-	 * Looks up the user with the givem `userEmail` in the cache
+	 * Looks up the user with the given `userOauth` in the cache
+	 * @param {string} userOauth The OAuth token of the the user to look up
 	 * @returns {Promise} A promise that will resolve to null or the full filesystem path to query for the user metadata
 	 */
-	getUserByEmail: function getUserByEmail(userEmail) {
-		return new Promise(function(resolve, reject) {
-			if(this.indexReady()) {
-				const uname = emailIndex.get(userEmail);
-				if(uname) {
-					return resolve(unameIndex.get(uname));
-				}
+	getUserByOauth(userOauth) {
+		return this.getUserIndex().then(function() {
+			const uname = this.oauthIndex.get(userOauth);
+			if(uname) {
+				return new Promise(function(resolve, reject) {
+					this._metastore.getUser(uname, (err, userInfo) => {
+						if(err) {
+							return reject(err);
+						}
+						return resolve(userInfo);
+					});
+				}.bind(this));
 			}
-			resolve(null);
+			return null;
 		}.bind(this));
-	},
+	}
 	/**
 	 * Returns all users
-	 * @returns {[string]} The array of all user names
+	 * @returns {Promise} A promise to resolve the array of user names
 	 */
-	getAllUsers: function getAllUsers() {
-		return new Promise(function(resolve, reject) {
-			if(this.indexReady()) {
-				const users = [];
-				for (const entry of unameIndex) {
-					users.push(entry[0]);
-				}
-				return resolve(users);
+	getAllUsers() {
+		return this.getUserIndex().then(function() {
+			const users = [];
+			for (const entry of this.userIndex) {
+				users.push(entry[0]);
 			}
-			resolve([]);
+			return users;
 		}.bind(this));
-	},
+	}
 	/**
 	 * This function is intended to be called when a metastore implementation creates a user - so that the 
 	 * new user can be added to the cache while the file lock is in use
 	 * @callback
 	 * @param {{?}} userInfo The user information object
 	 */
-	createUser: function createUser(userInfo) {
+	createUser(userInfo) {
 		return new Promise(function(resolve, reject) {
 			if(this.indexReady()) {
+				//if the index has been initialized, update it
 				let u = Object.create(null);
 				u.dir = userInfo.properties.location;
 				u.email = userInfo.email;
-				unameIndex.set(userInfo.username, u);
-				emailIndex.set(userInfo.email, userInfo.username);
+				this.oauthIndex.set(userInfo.username, u);
+				this.emailIndex.set(userInfo.email, userInfo.username);
+				this.userIndex.set(userInfo.username, {email: userInfo.email, oauth: userInfo.oauth});
 				return this.flush().then(() => {
 					resolve();
 				});
 			}
-			reject(new Error("Failed to create new user in index: "+userInfo.username));
+			resolve();
+			//reject(new Error("Failed to create new user in index: "+userInfo.username));
 		}.bind(this));
-	},
+	}
 	/**
 	 * This function is intended to be called when a metastore implementation deletes a user - so that the 
 	 * user can be removed from the cache while the file lock is in use
 	 * @callback
 	 * @param {{?}} userInfo The user information object
 	 */
-	deleteUser: function deleteUser(userId) {
+	deleteUser(userId) {
 		return new Promise(function(resolve, reject) {
 			if(this.indexReady()) {
-				const id = unameIndex.get(userId);
+				//if the index has been initialized, update it
+				//TODO
+				const id = this.userIndex.get(userId);
 				if(id) {
-					emailIndex.delete(id.email);
-					unameIndex.delete(userId);
+					this.emailIndex.delete(id.email);
+					if(id.oauth) {
+						this.oauthIndex.delete(id.oauth);
+					}
 					return this.flush().then(() => {
 						resolve();
 					});
 				}
 			}
-			reject(new Error("Failed to delete user from index: "+userId));
+			resolve();
+			//reject(new Error("Failed to delete user from index: "+userId));
 		}.bind(this));
-	},
+	}
 	/**
 	 * This function is intended to be called when a metastore implementation puts (updates) a user - so that the 
 	 * caches can be updated while the file lock is in use
 	 * @callback
 	 * @param {{?}} userInfo The user information object
 	 */
-	updateUser: function updateUser(oldInfo, newInfo) {
+	updateUser(oldInfo, newInfo) {
 		return new Promise(function(resolve, reject) {
 			if(this.indexReady()) {
-				const oldUser = unameIndex.get(oldInfo.username);
+				//if the index is ready update it, otherwise, no-op
+				const oldUser = this.userIndex.get(oldInfo.username);
 				if(oldUser) {
-					unameIndex.delete(oldInfo.username);
-					emailIndex.delete(oldUser.email);
+					if(oldUser.oauth) {
+						this.oauthIndex.delete(oldInfo.oauth);
+					}
+					this.emailIndex.delete(oldUser.email);
 				}
-				let u = Object.create(null);
-				u.dir = newInfo.properties.location;
-				u.email = newInfo.email;
-				unameIndex.set(newInfo.username, u);
-				emailIndex.set(newInfo.email, newInfo.username);
+				if(newInfo.oauth) {
+					this.oauthIndex.set(newInfo.oauth, newInfo.username);
+				}
+				this.emailIndex.set(newInfo.email, newInfo.username);
+				this.userIndex.set(newInfo.username, {email: newInfo.email, oauth: newInfo.oauth});
 				return this.flush().then(() => {
 					resolve();
 				});
 			}
-			reject(new Error("Failed to update user in index: "+oldInfo.username));
+			resolve();
+			//reject(new Error("Failed to update user in index: "+oldInfo.username));
 		}.bind(this));
-	},
+	}
+	/**
+	 * Returns if the index is ready for use
+	 * @returns true if the index has been initialized, false otherwise
+	 */
+	indexReady() {
+		return this.oauthIndex && this.emailIndex && this.userIndex;
+	}
+	/**
+	 * Read or create the user name and email indexes. If the indexes do not exist, or there was some problem reading them
+	 * the user directories are re-scanned to ensure consistency
+	 * @returns {Promise} A promise to load the caches. Rejects if the caches could not be loaded
+	 */
+	getUserIndex() {
+		return new Promise(function(resolve, reject) {
+			if(this.oauthIndex && this.emailIndex && this.userIndex) {
+				return resolve();
+			}
+			return this.readIndexFiles().then(() => {
+				resolve();
+			}, function() { 
+				resolve(this.createIndex());
+			}.bind(this));
+		}.bind(this));
+	}
+	/**
+	 * Try to read the index files from the workspace metadata
+	 * @returns {Promise} A promise to read the files. The promise is rejected if the files fail to read or fail to parse
+	 */
+	readIndexFiles() {
+		return new Promise(function(resolve, reject) {
+			fs.readFile(path.join(this._workspaceDir, OAUTH_INDEX_NAME), "utf8", function(err, contents) {
+				if(err || typeof contents !== 'string') {
+					reject(err);
+				}
+				try {
+					this.oauthIndex = new Map(JSON.parse(contents));
+					fs.readFile(path.join(this._workspaceDir, EMAIL_INDEX_NAME), "utf8", function(err, contents) {
+						if(err || typeof contents !== 'string') {
+							this.oauthIndex = null; //reset it
+							reject(err);
+						}
+						this.emailIndex = new Map(JSON.parse(contents));
+						fs.readFile(path.join(this._workspaceDir, UNAME_INDEX_NAME), "utf8", function(err, contents) {
+							if(err || typeof contents !== 'string') {
+								this.oauthIndex = null; //reset it
+								this.emailIndex = null;
+								reject(err);
+							}
+							this.userIndex = new Map(JSON.parse(contents));
+							resolve();
+						}.bind(this));
+					}.bind(this));
+				} catch(err) {
+					this.oauthIndex = null;
+					this.emailIndex = null;
+					this.userIndex = null;
+					return reject(err);
+				}
+			}.bind(this));
+		}.bind(this));
+	}
+	/** 
+	 * Crawl the filesystem and create the indexes
+	 * @returns {Promise} A promise to resolve the index once built
+	 */
+	createIndex() {
+		return fs.readdirAsync(this._workspaceDir).then(function(dirs) {
+			this.oauthIndex = new Map();
+			this.emailIndex = new Map();
+			this.userIndex = new Map();
+			return Promise.all(dirs.map(function(f) {
+				const d = path.join(this._workspaceDir, f);
+				return fs.statAsync(d).then(function(stat) {
+					if(stat.isDirectory() && !f.startsWith('.')) {
+						return this.readUser(d);
+					}
+				}.bind(this));
+			}.bind(this)));
+		}.bind(this));
+	}
+	/**
+	 * Reads a user from the filesystem. Reading is delegated back to the backing metastore for this index.
+	 * @param {*} dir The directory to read
+	 * @returns {Promise} A promise to read the user from the given directory. If the read fails, the exception is ignored 
+	 * so the index crawling can continue.
+	 */
+	readUser(dir) {
+		return fs.readdirAsync(dir).then(function(dirs) {
+			return Promise.all(dirs.map(function(f) {
+				return new Promise(function(resolve, reject) {
+					this._metastore.getUser(f, function(err, userInfo) {
+						if(!err && userInfo) {
+							this.userIndex.set(userInfo.username, {email: userInfo.email, oauth: userInfo.oauth});
+							this.emailIndex.set(userInfo.email, userInfo.username);
+							if(userInfo.oauth) {
+								this.oauthIndex.set(userInfo.oauth, userInfo.username);
+							}
+						}
+						this.flush().then(() => {
+							resolve();
+						});
+					}.bind(this));
+				}.bind(this));
+			}.bind(this)));
+		}.bind(this));
+	}
 	/**
 	 * Flush the current cache entries to the filesystem
 	 */
-	flush: function flush() {
-		const p = path.join(_workspaceDir, UNAME_INDEX_NAME);
-		return fs.writeFileAsync(p, JSON.stringify([...unameIndex], null, '\t')).then(() => {
-			const p = path.join(_workspaceDir, EMAIL_INDEX_NAME);
-			return fs.writeFileAsync(p, JSON.stringify([...emailIndex], null, '\t'));
-		});
+	flush() {
+		const p = path.join(this._workspaceDir, OAUTH_INDEX_NAME);
+		return fs.writeFileAsync(p, JSON.stringify([...this.oauthIndex], null, '\t')).then(function() {
+			const p = path.join(this._workspaceDir, EMAIL_INDEX_NAME);
+			return fs.writeFileAsync(p, JSON.stringify([...this.emailIndex], null, '\t')).then(function() {
+				const p = path.join(this._workspaceDir, UNAME_INDEX_NAME);
+				return fs.writeFileAsync(p, JSON.stringify([...this.userIndex], null, '\t'));
+			}.bind(this));
+		}.bind(this));
 	}
-});
-
-/**
- * Try to read the index files from the workspace metadata
- * @returns {Promise} A promise to read the files. The promise is rejected if the files fail to read or fail to parse
- */
-function readIndexFiles() {
-	return new Promise(function(resolve, reject) {
-		fs.readFile(path.join(_workspaceDir, UNAME_INDEX_NAME), "utf8", (err, contents) => {
-			if(err || typeof contents !== 'string') {
-				reject();
-			}
-			try {
-				unameIndex = new Map(JSON.parse(contents));
-				fs.readFile(path.join(_workspaceDir, UNAME_INDEX_NAME), "utf8", (err, contents) => {
-					if(err || typeof contents !== 'string') {
-						unameIndex = null; //reset it
-						reject();
-					}
-					emailIndex = new Map(JSON.parse(contents));
-					resolve();
-				});
-			} catch(err) {
-				unameIndex = null;
-				emailIndex = null;
-				return reject();
-			}
-		});
-	});
 }
-
-function createIndex(cache) {
-	return fs.readdirAsync(_workspaceDir).then(dirs => {
-		unameIndex = new Map();
-		emailIndex = new Map();
-		return Promise.all(dirs.map((f) => {
-			const d = path.join(_workspaceDir, f);
-			return fs.statAsync(d).then(stat => {
-				if(stat.isDirectory() && !f.startsWith('.')) {
-					return readUser(cache, d);
-				}
-			});
-		}));
-	}).then(() => {
-		return;
-	});
-}
-
-function readUser(cache, dir) {
-	return fs.readdirAsync(dir).then(dirs => {
-		return Promise.all(dirs.map((f) => {
-			const d = path.join(dir, f);
-			return fs.statAsync(d).then(stat => {
-				if(stat.isDirectory()) {
-					console.log("Directory: "+d);
-					const ujson = path.join(d, 'user.json');
-					return fs.readFileAsync(ujson).then(contents => {
-						try {
-							const user = JSON.parse(contents),
-								u = Object.create(null);
-							u.dir = d;
-							if(user.Properties && user.Properties.Email) {
-								u.email = user.Properties.Email;
-								emailIndex.set(user.Properties.Email, user.UserName);
-							}
-							unameIndex.set(user.UserName, u);
-							return cache.flush();
-						} catch (perr) {
-							//ignore, keep going
-							logger.error("Failed to parse user metadata: "+ perr.message);
-						}
-					}, (err) => {console.log("Failed to read: "+ujson+" ERROR: "+err.message)});
-				}
-			});
-		}));
-	}).then(() => {
-		return;
-	});
-}
+module.exports = UserIndex;

--- a/modules/orionode/lib/metastore/util/userIndex.js
+++ b/modules/orionode/lib/metastore/util/userIndex.js
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials are made 
+ * available under the terms of the Eclipse Public License v1.0 
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution 
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html). 
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const fs = require("fs"),
+	path = require("path"),
+	log4js = require('log4js'),
+	logger = log4js.getLogger("user-index");
+
+const UNAME_INDEX_NAME = ".unameIndex",
+	EMAIL_INDEX_NAME = ".emailIndex";
+
+let _workspaceDir,
+	unameIndex,
+	emailIndex;
+
+/**
+ * Creates a new user index. It is up to the backing metastore to initialize the index prior to its use.
+ * @param {string} workspaceDir The root of the server workspace
+ * @since 18.0
+ */
+function UserIndex(workspaceDir) {
+	_workspaceDir = workspaceDir;
+	unameIndex = null;
+	emailIndex = null;
+}
+module.exports = UserIndex;
+
+Object.assign(UserIndex.prototype, {
+	/**
+	 * Read or create the user name and email indexes. If the indexes do not exist, or there was some problem reading them
+	 * the user directories are re-scanned to ensure consistency
+	 * @returns {Promise} A promise to load the caches. Rejects if the caches could not be loaded
+	 */
+	getUserIndex: function getUserIndex() {
+		return new Promise(function(resolve, reject) {
+			if(unameIndex && emailIndex) {
+				return resolve();
+			}
+			return readIndexFiles().then(() => {
+				resolve();
+			}, function() { 
+				resolve(createIndex(this, _workspaceDir));
+			}.bind(this)) 
+		}.bind(this));
+	},
+	/**
+	 * Returns if the index is ready for use
+	 * @returns true if the index has been initialized, false otherwise
+	 */
+	indexReady: function indexReady() {
+		return unameIndex && emailIndex;
+	},
+	/**
+	 * Looks up the user with the givem `userName` in the cache
+	 * @returns {Promise} A promise that will resolve to null or the full filesystem path to query for the user metadata
+	 */
+	getUserByUname: function getUserByUname(userName) {
+		return new Promise(function(resolve, reject) {
+			if(this.indexReady()) {
+				return resolve(unameIndex.get(userName));
+			}
+			resolve(null);
+		}.bind(this));
+	},
+	/**
+	 * Looks up the user with the givem `userEmail` in the cache
+	 * @returns {Promise} A promise that will resolve to null or the full filesystem path to query for the user metadata
+	 */
+	getUserByEmail: function getUserByEmail(userEmail) {
+		return new Promise(function(resolve, reject) {
+			if(this.indexReady()) {
+				const uname = emailIndex.get(userEmail);
+				if(uname) {
+					return resolve(unameIndex.get(uname));
+				}
+			}
+			resolve(null);
+		}.bind(this));
+	},
+	/**
+	 * Returns all users
+	 * @returns {[string]} The array of all user names
+	 */
+	getAllUsers: function getAllUsers() {
+		return new Promise(function(resolve, reject) {
+			if(this.indexReady()) {
+				const users = [];
+				for (const entry of unameIndex) {
+					users.push(entry[0]);
+				}
+				return resolve(users);
+			}
+			resolve([]);
+		}.bind(this));
+	},
+	/**
+	 * This function is intended to be called when a metastore implementation creates a user - so that the 
+	 * new user can be added to the cache while the file lock is in use
+	 * @callback
+	 * @param {{?}} userInfo The user information object
+	 */
+	createUser: function createUser(userInfo) {
+		return new Promise(function(resolve, reject) {
+			if(this.indexReady()) {
+				let u = Object.create(null);
+				u.dir = userInfo.properties.location;
+				u.email = userInfo.email;
+				unameIndex.set(userInfo.username, u);
+				emailIndex.set(userInfo.email, userInfo.username);
+				return this.flush().then(() => {
+					resolve();
+				});
+			}
+			reject(new Error("Failed to create new user in index: "+userInfo.username));
+		}.bind(this));
+	},
+	/**
+	 * This function is intended to be called when a metastore implementation deletes a user - so that the 
+	 * user can be removed from the cache while the file lock is in use
+	 * @callback
+	 * @param {{?}} userInfo The user information object
+	 */
+	deleteUser: function deleteUser(userId) {
+		return new Promise(function(resolve, reject) {
+			if(this.indexReady()) {
+				const id = unameIndex.get(userId);
+				if(id) {
+					emailIndex.delete(id.email);
+					unameIndex.delete(userId);
+					return this.flush().then(() => {
+						resolve();
+					});
+				}
+			}
+			reject(new Error("Failed to delete user from index: "+userId));
+		}.bind(this));
+	},
+	/**
+	 * This function is intended to be called when a metastore implementation puts (updates) a user - so that the 
+	 * caches can be updated while the file lock is in use
+	 * @callback
+	 * @param {{?}} userInfo The user information object
+	 */
+	updateUser: function updateUser(oldInfo, newInfo) {
+		return new Promise(function(resolve, reject) {
+			if(this.indexReady()) {
+				const oldUser = unameIndex.get(oldInfo.username);
+				if(oldUser) {
+					unameIndex.delete(oldInfo.username);
+					emailIndex.delete(oldUser.email);
+				}
+				let u = Object.create(null);
+				u.dir = newInfo.properties.location;
+				u.email = newInfo.email;
+				unameIndex.set(newInfo.username, u);
+				emailIndex.set(newInfo.email, newInfo.username);
+				return this.flush().then(() => {
+					resolve();
+				});
+			}
+			reject(new Error("Failed to update user in index: "+oldInfo.username));
+		}.bind(this));
+	},
+	/**
+	 * Flush the current cache entries to the filesystem
+	 */
+	flush: function flush() {
+		const p = path.join(_workspaceDir, UNAME_INDEX_NAME);
+		return fs.writeFileAsync(p, JSON.stringify([...unameIndex], null, '\t')).then(() => {
+			const p = path.join(_workspaceDir, EMAIL_INDEX_NAME);
+			return fs.writeFileAsync(p, JSON.stringify([...emailIndex], null, '\t'));
+		});
+	}
+});
+
+/**
+ * Try to read the index files from the workspace metadata
+ * @returns {Promise} A promise to read the files. The promise is rejected if the files fail to read or fail to parse
+ */
+function readIndexFiles() {
+	return new Promise(function(resolve, reject) {
+		fs.readFile(path.join(_workspaceDir, UNAME_INDEX_NAME), "utf8", (err, contents) => {
+			if(err || typeof contents !== 'string') {
+				reject();
+			}
+			try {
+				unameIndex = new Map(JSON.parse(contents));
+				fs.readFile(path.join(_workspaceDir, UNAME_INDEX_NAME), "utf8", (err, contents) => {
+					if(err || typeof contents !== 'string') {
+						unameIndex = null; //reset it
+						reject();
+					}
+					emailIndex = new Map(JSON.parse(contents));
+					resolve();
+				});
+			} catch(err) {
+				unameIndex = null;
+				emailIndex = null;
+				return reject();
+			}
+		});
+	});
+}
+
+function createIndex(cache) {
+	return fs.readdirAsync(_workspaceDir).then(dirs => {
+		unameIndex = new Map();
+		emailIndex = new Map();
+		return Promise.all(dirs.map((f) => {
+			const d = path.join(_workspaceDir, f);
+			return fs.statAsync(d).then(stat => {
+				if(stat.isDirectory() && !f.startsWith('.')) {
+					return readUser(cache, d);
+				}
+			});
+		}));
+	}).then(() => {
+		return;
+	});
+}
+
+function readUser(cache, dir) {
+	return fs.readdirAsync(dir).then(dirs => {
+		return Promise.all(dirs.map((f) => {
+			const d = path.join(dir, f);
+			return fs.statAsync(d).then(stat => {
+				if(stat.isDirectory()) {
+					console.log("Directory: "+d);
+					const ujson = path.join(d, 'user.json');
+					return fs.readFileAsync(ujson).then(contents => {
+						try {
+							const user = JSON.parse(contents),
+								u = Object.create(null);
+							u.dir = d;
+							if(user.Properties && user.Properties.Email) {
+								u.email = user.Properties.Email;
+								emailIndex.set(user.Properties.Email, user.UserName);
+							}
+							unameIndex.set(user.UserName, u);
+							return cache.flush();
+						} catch (perr) {
+							//ignore, keep going
+							logger.error("Failed to parse user metadata: "+ perr.message);
+						}
+					}, (err) => {console.log("Failed to read: "+ujson+" ERROR: "+err.message)});
+				}
+			});
+		}));
+	}).then(() => {
+		return;
+	});
+}

--- a/modules/orionode/lib/user.js
+++ b/modules/orionode/lib/user.js
@@ -71,7 +71,6 @@ function userJSON(user, options) {
 	return {
 		FullName: user.fullname,
 		UserName: user.username,
-		Location: api.join(options.usersRoot, user.username),
 		Email: user.email,
 		EmailConfirmed: emailConfirmed(user),
 		HasPassword: true,
@@ -472,7 +471,7 @@ module.exports.router = function router(options) {
 							api.writeError(500, res, err.message);
 							return;
 						}
-						if (existing && existing.length) {
+						if (existing && (id !== existing.username)) {
 							api.writeError(409, res, "This account is already linked to someone else");
 							return;
 						}

--- a/modules/orionode/test/endpoints/test-users.js
+++ b/modules/orionode/test/endpoints/test-users.js
@@ -389,7 +389,7 @@ describe("Users endpoint", function() {
 				.set('Orion-Version', 1)
 				.expect(404, done);
 		});
-		it("testCreateDeleteUser - ADMIN", function(done) {
+		it("testCreateDeleteUser", function(done) {
 			var json = {UserName: "u12", Email: 'u12@bar.org', FullName: "u12 Bar", Password: "1234"};
 			request()
 				.post(CONTEXT_PATH + '/users')
@@ -400,6 +400,93 @@ describe("Users endpoint", function() {
 					request()
 						.delete(CONTEXT_PATH + '/users/u12')
 						.expect(200, done) //TODO what to do in single user mode?
+				});
+		});
+		it("testUser", function(done) {
+			var json = {UserName: "get1", Email: 'get1@mail.ca', FullName: "get one", Password: "1234"};
+			request()
+				.post(CONTEXT_PATH + '/users')
+				.send(json)
+				.expect(201)
+				.end(function(err, res) {
+					testHelper.throwIfError(err);
+					request()
+						.get(CONTEXT_PATH + '/users/get1')
+						.expect(200, done);
+				});
+		});
+		it("testGetUserByEmail - email not confirmed", function(done) {
+			var json = {UserName: "get2", Email: 'get2@mail.ca', FullName: "get two", Password: "1234"};
+			request()
+				.post(CONTEXT_PATH + '/users')
+				.send(json)
+				.expect(201)
+				.end(function(err, res) {
+					testHelper.throwIfError(err);
+					request()
+						.post(CONTEXT_PATH + '/useremailconfirmation')
+						.send({Email: "get2@mail.ca"})
+						.expect(400, done) //email is not confirmed, 400 is expected
+				});
+		});
+		it("testGetUserByOauth - no set oauth", function(done) {
+			var json = {UserName: "get3", Email: 'get3@mail.ca', FullName: "get three", Password: "1234", OAuth: "ABCDEF"};
+			request()
+				.post(CONTEXT_PATH + '/users')
+				.send(json)
+				.expect(201)
+				.end(function(err, res) {
+					testHelper.throwIfError(err);
+					request()
+						.put(CONTEXT_PATH + '/users/get3')
+						.send({OAuth: "ABCDEF"})
+						.expect(200)
+						.end((err, res) => {
+							testHelper.throwIfError(err);
+							done();
+						});
+				});
+		});
+		it("testGetUserByOauth - oauth set", function(done) {
+			var json = {UserName: "get4", Email: 'get4@mail.ca', FullName: "get four", Password: "1234", OAuth: "ABCDEF4"};
+			request()
+				.post(CONTEXT_PATH + '/users')
+				.send(json)
+				.expect(201)
+				.end(function(err, res) {
+					testHelper.throwIfError(err);
+					request()
+						.put(CONTEXT_PATH + '/users/get4')
+						.send({OAuth: "ABCDEF4"})
+						.expect(200)
+						.end((err, res) => {
+							testHelper.throwIfError(err);
+							request()
+								.put(CONTEXT_PATH + '/users/get4')
+								.send({OAuth: "ABCDEF4"})
+								.expect(200, done);
+						});
+				});
+		});
+		it("testGetUserByOauth - null sent, remove oauth", function(done) {
+			var json = {UserName: "get5", Email: 'get5@mail.ca', FullName: "get five", Password: "1234", OAuth: "ABCDEF5"};
+			request()
+				.post(CONTEXT_PATH + '/users')
+				.send(json)
+				.expect(201)
+				.end(function(err, res) {
+					testHelper.throwIfError(err);
+					request()
+						.put(CONTEXT_PATH + '/users/get5')
+						.send({OAuth: "ABCDEF5"})
+						.expect(200)
+						.end((err, res) => {
+							testHelper.throwIfError(err);
+							request()
+								.put(CONTEXT_PATH + '/users/get5')
+								.send({OAuth: null})
+								.expect(200, done);
+						});
 				});
 		});
 	});


### PR DESCRIPTION
Provides an index like Java did for reading the filesystem to cache all users - where the cache is used for getAllUsers / getUserByEmail / getUserByOAuth API calls from the underlying metastore.

This cache should also be able to read the users from orionhub.org (still needs some more testing there).