### PR TITLE
[nobug] Change noTimeout to check against "true".

### DIFF
--- a/bundles/org.eclipse.orion.client.core/web/orion/xhr.js
+++ b/bundles/org.eclipse.orion.client.core/web/orion/xhr.js
@@ -158,7 +158,7 @@ define([
 			if (typeof options.responseType === 'string') { //$NON-NLS-0$
 				xhr.responseType = options.responseType;
 			}
-			if (typeof options.timeout === 'number' && localStorage.noTimeout !== "false") { //$NON-NLS-0$
+			if (typeof options.timeout === 'number' && localStorage.noTimeout !== "true") { //$NON-NLS-0$
 				if (typeof xhr.timeout === 'number') { //$NON-NLS-0$
 					// Browser supports XHR timeout
 					xhr.timeout = options.timeout;


### PR DESCRIPTION
Currently to disable xhr timeout you must set localStorage.noTimeout to
"false" which is counter intuitive.

Signed-off-by: Casey Flynn <caseyflynn@google.com>