### PR TITLE
Bug 525248 - CSS content assist could help with psuedo-classes

### DIFF
--- a/bundles/org.eclipse.orion.client.webtools/web/js-tests/webtools/cssContentAssistTests.js
+++ b/bundles/org.eclipse.orion.client.webtools/web/js-tests/webtools/cssContentAssistTests.js
@@ -114,9 +114,11 @@ define([
 	describe('CSS Content Assist Tests', function() {
 		it('General - empty file', function() {
 			var expected = [
-				{ description: 'Rule : element { }', proposal: 'element {\n\t\n}'},
-				{ description: 'Rule : #id { }', proposal: '#id {\n\t\n}'},
-				{ description: 'Rule : .class { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: element { }', proposal: 'element {\n\t\n}'},
+				{ description: 'Rule: #id { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: .class { }', proposal: '.class {\n\t\n}'},
+				{ description: 'Rule: :pseudo-class { }', proposal: ':pseudoclass {\n\t\n}'},
+				{ description: 'Rule: ::pseudo-element { }', proposal: '::pseudoelement {\n\t\n}'},
 				{ description: '@charset', proposal: '@charset "charset";'},
 				{ description: '@import', proposal: '@import "url";'},
 				{ description: '@namespace', proposal: '@namespace "url";'},
@@ -130,9 +132,11 @@ define([
 		});
 		it('General - after rule close', function() {
 			var expected = [
-				{ description: 'Rule : element { }', proposal: 'element {\n\t\n}'},
-				{ description: 'Rule : #id { }', proposal: '#id {\n\t\n}'},
-				{ description: 'Rule : .class { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: element { }', proposal: 'element {\n\t\n}'},
+				{ description: 'Rule: #id { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: .class { }', proposal: '.class {\n\t\n}'},
+				{ description: 'Rule: :pseudo-class { }', proposal: ':pseudoclass {\n\t\n}'},
+				{ description: 'Rule: ::pseudo-element { }', proposal: '::pseudoelement {\n\t\n}'},
 				{ description: '@charset', proposal: '@charset "charset";'},
 				{ description: '@import', proposal: '@import "url";'},
 				{ description: '@namespace', proposal: '@namespace "url";'},
@@ -146,9 +150,11 @@ define([
 		});
 		it('General - after @import', function() {
 			var expected = [
-				{ description: 'Rule : element { }', proposal: 'element {\n\t\n}'},
-				{ description: 'Rule : #id { }', proposal: '#id {\n\t\n}'},
-				{ description: 'Rule : .class { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: element { }', proposal: 'element {\n\t\n}'},
+				{ description: 'Rule: #id { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: .class { }', proposal: '.class {\n\t\n}'},
+				{ description: 'Rule: :pseudo-class { }', proposal: ':pseudoclass {\n\t\n}'},
+				{ description: 'Rule: ::pseudo-element { }', proposal: '::pseudoelement {\n\t\n}'},
 				{ description: '@charset', proposal: '@charset "charset";'},
 				{ description: '@import', proposal: '@import "url";'},
 				{ description: '@namespace', proposal: '@namespace "url";'},
@@ -162,9 +168,11 @@ define([
 		});
 		it('General - ru prefix', function() {
 			var expected = [
-				{ description: 'Rule : element { }', proposal: 'element {\n\t\n}'},
-				{ description: 'Rule : #id { }', proposal: '#id {\n\t\n}'},
-				{ description: 'Rule : .class { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: element { }', proposal: 'element {\n\t\n}'},
+				{ description: 'Rule: #id { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: .class { }', proposal: '.class {\n\t\n}'},
+				{ description: 'Rule: :pseudo-class { }', proposal: ':pseudoclass {\n\t\n}'},
+				{ description: 'Rule: ::pseudo-element { }', proposal: '::pseudoelement {\n\t\n}'},
 			];
 			return runTest({buffer: "abc { a: 1; } ru "}, 'ru', 16, expected);
 		});
@@ -278,9 +286,11 @@ define([
 		});
 		it('Conditional at rules media 4', function() {
 			var expected = [
-				{ description: 'Rule : element { }', proposal: 'element {\n\t\n}'},
-				{ description: 'Rule : #id { }', proposal: '#id {\n\t\n}'},
-				{ description: 'Rule : .class { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: element { }', proposal: 'element {\n\t\n}'},
+				{ description: 'Rule: #id { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: .class { }', proposal: '.class {\n\t\n}'},
+				{ description: 'Rule: :pseudo-class { }', proposal: ':pseudoclass {\n\t\n}'},
+				{ description: 'Rule: ::pseudo-element { }', proposal: '::pseudoelement {\n\t\n}'},
 				{ description: '@media', proposal: '@media media-query-list {\n\t\n}'},
 				{ description: '@supports', proposal: '@supports (condition) {\n\t\n}'},
 				{ description: '@page', proposal: '@page page-selector-list {\n\t\n}'},
@@ -314,9 +324,11 @@ define([
 		});
 		it('Conditional at rules supports 4', function() {
 			var expected = [
-				{ description: 'Rule : element { }', proposal: 'element {\n\t\n}'},
-				{ description: 'Rule : #id { }', proposal: '#id {\n\t\n}'},
-				{ description: 'Rule : .class { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: element { }', proposal: 'element {\n\t\n}'},
+				{ description: 'Rule: #id { }', proposal: '#id {\n\t\n}'},
+				{ description: 'Rule: .class { }', proposal: '.class {\n\t\n}'},
+				{ description: 'Rule: :pseudo-class { }', proposal: ':pseudoclass {\n\t\n}'},
+				{ description: 'Rule: ::pseudo-element { }', proposal: '::pseudoelement {\n\t\n}'},
 				{ description: '@media', proposal: '@media media-query-list {\n\t\n}'},
 				{ description: '@supports', proposal: '@supports (condition) {\n\t\n}'},
 				{ description: '@page', proposal: '@page page-selector-list {\n\t\n}'},

--- a/bundles/org.eclipse.orion.client.webtools/web/webtools/cssContentAssist.js
+++ b/bundles/org.eclipse.orion.client.webtools/web/webtools/cssContentAssist.js
@@ -28,28 +28,42 @@ define([
 	CssContentAssistProvider.prototype = new mTemplates.TemplateContentAssist([], []);
 	
 	
-	// TODO Support additional templates
+	// TODO Support additional templates (i.e. universal selector, attribute selector)
 	var ruleTemplates = [
 		{
 			prefix: "Rule", //$NON-NLS-1$
 			description: Messages['elementRuleDescription'],
 			template: "${element} {\n\t${cursor}\n}", //$NON-NLS-1$
 			doc: Messages['elementRuleDoc'],
-			url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax#CSS_rulesets" //$NON-NLS-1$
+			url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors" //$NON-NLS-1$
 		},
 		{
 			prefix: "Rule", //$NON-NLS-1$
 			description: Messages['idRuleDescription'],
 			template: "#${id} {\n\t${cursor}\n}", //$NON-NLS-1$
 			doc: Messages['idRuleDoc'],
-			url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax#CSS_rulesets" //$NON-NLS-1$
+			url: "https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors" //$NON-NLS-1$
 		},
 		{
 			prefix: "Rule", //$NON-NLS-1$
 			description: Messages['classRuleDescription'],
-			template: "#${id} {\n\t${cursor}\n}", //$NON-NLS-1$
+			template: ".${class} {\n\t${cursor}\n}", //$NON-NLS-1$
 			doc: Messages['classRuleDoc'],
-			url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax#CSS_rulesets" //$NON-NLS-1$
+			url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors" //$NON-NLS-1$
+		},
+		{
+			prefix: "Rule", //$NON-NLS-1$
+			description: Messages['pseudoClassRuleDescription'],
+			template: ":${pseudoclass} {\n\t${cursor}\n}", //$NON-NLS-1$
+			doc: Messages['pseudoClassRuleDoc'],
+			url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes" //$NON-NLS-1$
+		},
+		{
+			prefix: "Rule", //$NON-NLS-1$
+			description: Messages['pseudoElementRuleDescription'],
+			template: "::${pseudoelement} {\n\t${cursor}\n}", //$NON-NLS-1$
+			doc: Messages['pseudoElementRuleDoc'],
+			url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements" //$NON-NLS-1$
 		},
 	];
 	//https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule

--- a/bundles/org.eclipse.orion.client.webtools/web/webtools/nls/root/messages.js
+++ b/bundles/org.eclipse.orion.client.webtools/web/webtools/nls/root/messages.js
@@ -299,16 +299,20 @@ define({//Default message bundle
 	//CSS content assist
 	// 'element' 'id' 'class' and 'attribute' can be replaced with translated text, but they are describing specific CSS structures
 	// See https://www.w3schools.com/cssref/css_selectors.asp
-	"elementRuleDescription": "Rule : element { }",
-	"idRuleDescription": "Rule : #id { }",
-	"classRuleDescription": "Rule : .class { }",
+	"elementRuleDescription": "Rule: element { }",
+	"idRuleDescription": "Rule: #id { }",
+	"classRuleDescription": "Rule: .class { }",
+	"pseudoClassRuleDescription": "Rule: :pseudo-class { }",
+	"pseudoElementRuleDescription": "Rule: ::pseudo-element { }",
 	"elementSelector": "element",
 	"idSelector": "#id",
 	"classSelector": ".class",
 	"attributeSelector": "[attribute]",
-	"elementRuleDoc": "A rule (ruleset) that applies to all elements that match the given name.",
+	"elementRuleDoc": "A rule (ruleset) that applies to all elements that match the given type.",
 	"classRuleDoc": "A rule (ruleset) that applies to elements based on the value of their class attribute.",
-	"idRuleDoc": "A rule (ruleset) that applies to elements based on the value of its id attribute.",
+	"idRuleDoc": "A rule (ruleset) that applies to an element based on the value of its id attribute.",
+	"pseudoClassRuleDoc": "A rule (ruleset) that applies to elements based on a particular state.",
+	"pseudoElementRuleDoc": "A rule (ruleset) that applies to specific parts of elements.",
 
 	// See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule
 	'charsetTemplateDoc': 'Defines the character set used by the style sheet.',


### PR DESCRIPTION
- partial fix for 525248 (templates only)
- updated template urls
- fixed class template to use . instead of #