### PR TITLE
BCD & DI AVT - The focus doesn't return to the menu zone after exit menu opened panels org-ids/web-ide-issues#1268

### DIFF
--- a/bundles/org.eclipse.orion.client.editor/web/orion/editor/find.js
+++ b/bundles/org.eclipse.orion.client.editor/web/orion/editor/find.js
@@ -300,6 +300,12 @@ define("orion/editor/find", [ //$NON-NLS-0$
 			var textView = this._editor.getTextView();
 			if (textView) {
 				textView.removeEventListener("Focus", this._listeners.onEditorFocus); //$NON-NLS-0$
+			}
+			this._returnFocus();
+		},
+		_returnFocus: function() {
+			var textView = this._editor.getTextView();
+			if (textView) {
 				textView.focus();
 			}
 		},

--- a/bundles/org.eclipse.orion.client.ui/web/orion/commandRegistry.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/commandRegistry.js
@@ -332,9 +332,7 @@ define([
 					parameterArea.classList.add("parameterPopup"); //$NON-NLS-0$
 					var originalFocusNode = window.document.activeElement;
 					closeFunction = function() {
-						if (originalFocusNode) {
-							originalFocusNode.focus();
-						}
+						lib.returnFocus(parameterArea, originalFocusNode);
 						tooltip.destroy();
 					};
 					var messageArea = document.createElement("div"); //$NON-NLS-0$
@@ -456,9 +454,7 @@ define([
 							parameterArea.classList.add("parameterPopup"); //$NON-NLS-0$
 							var originalFocusNode = window.document.activeElement;
 							var focusNode = this._parameterCollector.getFillFunction(commandInvocation, function() {
-								if (originalFocusNode) {
-									originalFocusNode.focus();
-								}
+								lib.returnFocus(parameterArea, originalFocusNode);
 								tooltip.destroy();
 								if (commandInvocation.domParent) commandInvocation.domParent.classList.remove("parameterPopupOpen"); //$NON-NLS-0$
 							}, cancelCallback)(parameterArea);

--- a/bundles/org.eclipse.orion.client.ui/web/orion/keyAssist.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/keyAssist.js
@@ -311,13 +311,10 @@ define([
 			if (!this.isVisible()) {
 				return;
 			}
-			var activeElement = document.activeElement;
 			var keyAssistDiv = this._keyAssistDiv;
-			var hasFocus = keyAssistDiv === activeElement || (keyAssistDiv.compareDocumentPosition(activeElement) & 16) !== 0;
-			keyAssistDiv.style.display = "none"; //$NON-NLS-1$
-			if (hasFocus && document.compareDocumentPosition(this._previousActiveElement) !== 1) {
-				this._previousActiveElement.focus();
-			}
+			lib.returnFocus(keyAssistDiv, this._previousActiveElement, function() {
+				keyAssistDiv.style.display = "none"; //$NON-NLS-1$
+			});
 			this._previousActiveElement = null;
 		},
 		isVisible: function () {

--- a/bundles/org.eclipse.orion.client.ui/web/orion/parameterCollectors.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/parameterCollectors.js
@@ -38,7 +38,7 @@ define(['i18n!orion/nls/messages', 'orion/webui/littlelib', 'orion/bidiUtils', '
 	
 		close: function () {
 			if (this._activeElements) {
-				lib.returnFocus(this._activeElements.parameterArea, this._oldFocusNode, function() {
+				lib.returnFocus(this._activeElements.slideContainer, this._oldFocusNode, function() {
 					if (this._activeElements.parameterArea) {
 						lib.empty(this._activeElements.parameterArea);
 					}

--- a/bundles/org.eclipse.orion.client.ui/web/orion/parameterCollectors.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/parameterCollectors.js
@@ -38,30 +38,31 @@ define(['i18n!orion/nls/messages', 'orion/webui/littlelib', 'orion/bidiUtils', '
 	
 		close: function () {
 			if (this._activeElements) {
-				if (this._activeElements.parameterArea) {
-					lib.empty(this._activeElements.parameterArea);
-				}
-				if (this._activeElements.slideContainer) {
-					this._activeElements.slideContainer.classList.remove("slideContainerActive"); //$NON-NLS-0$
-				}
-				if (this._activeElements.dismissArea) {
-					 lib.empty(this._activeElements.dismissArea);
-				}
-				if (this._activeElements.commandNode) {
-					this._activeElements.commandNode.classList.remove("activeCommand"); //$NON-NLS-0$
-				}
-				if (this._activeElements.closeTooltip) {
-		            this._activeElements.closeTooltip.destroy();
-		            this._activeElements.closeTooltip = null;
-		        }
-				this._toolbarLayoutFunction(this._activeElements);
-				if (this._activeElements.onClose) {
-					this._activeElements.onClose();
-				}
-				if (this._oldFocusNode) {
-					this._oldFocusNode.focus();
-					this._oldFocusNode = null;
-				}
+				lib.returnFocus(this._activeElements.parameterArea, this._oldFocusNode, function() {
+					if (this._activeElements.parameterArea) {
+						lib.empty(this._activeElements.parameterArea);
+					}
+					if (this._activeElements.slideContainer) {
+						this._activeElements.slideContainer.classList.remove("slideContainerActive"); //$NON-NLS-0$
+					}
+					if (this._activeElements.dismissArea) {
+						 lib.empty(this._activeElements.dismissArea);
+					}
+					if (this._activeElements.commandNode) {
+						this._activeElements.commandNode.classList.remove("activeCommand"); //$NON-NLS-0$
+					}
+					if (this._activeElements.closeTooltip) {
+			            this._activeElements.closeTooltip.destroy();
+			            this._activeElements.closeTooltip = null;
+			        }
+					this._toolbarLayoutFunction(this._activeElements);
+					if (this._activeElements.onClose) {
+						this._activeElements.onClose();
+					}
+					if (this._oldFocusNode) {
+						this._oldFocusNode = null;
+					}
+				}.bind(this));
 			}
 			this._activeElements = null;
 		},

--- a/bundles/org.eclipse.orion.client.ui/web/orion/searchAndReplace/textSearcher.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/searchAndReplace/textSearcher.js
@@ -304,7 +304,10 @@ define([
 				}
 			}.bind(this));
 		},
-	    _initCompletion: function(searchStringInput) {
+		_returnFocus: function() {
+			// Let parameter collector handle this
+		},
+		_initCompletion: function(searchStringInput) {
 			if(this._completion){
 				this._completion.setInputField(searchStringInput);
 			} else { //Create the inputCompletion lazily.
@@ -370,6 +373,9 @@ define([
 			image.addEventListener("keydown", function(e) { //$NON-NLS-0$
 				if (e.keyCode === lib.KEY.SPACE || e.keyCode === lib.KEY.ENTER) {
 					toggle();
+				}
+				if (e.keyCode === lib.KEY.ESCAPE) {
+					that.hide();
 				}
 			});
 			parent.appendChild(image);

--- a/bundles/org.eclipse.orion.client.ui/web/orion/webui/Slideout.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/webui/Slideout.js
@@ -121,17 +121,9 @@ define([
 		 * Hides the slideout.
 		 */
 		hide: function() {
-			// remove focus from activeElement if it is child of slideout
-			var activeElement = document.activeElement;
-			while (activeElement) {
-				if (this._wrapperNode === activeElement) {
-					document.activeElement.blur();
-				}
-				activeElement = activeElement.parentNode;
-			}
-			
+			lib.returnFocus(this._wrapperNode, this._previousActiveElement);
 			this._previousActiveElement = null;
-			
+
 			// step 1: remove CSS class which positions slideout within visible range
 			this._wrapperNode.classList.remove("slideoutWrapperVisible"); //$NON-NLS-0$
 			

--- a/bundles/org.eclipse.orion.client.ui/web/orion/webui/dialog.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/webui/dialog.js
@@ -220,28 +220,24 @@ define(['i18n!orion/nls/messages', 'orion/webui/littlelib', 'orion/uiUtils'],
 		 * as destroying resources.
 		 */
 		hide: function(keepCurrentModal) {
-			var activeElement = document.activeElement;
-			var hasFocus = this.$frameParent === activeElement || (this.$frameParent.compareDocumentPosition(activeElement) & 16) !== 0;
-			var originalFocus = this.$originalFocus;
-			if(!keepCurrentModal && modalDialogManager.dialog === this) {
-				modalDialogManager.dialog = null;
-			}
-			if (typeof this._beforeHiding === "function") { //$NON-NLS-0$
-				this._beforeHiding();
-			}
-			if (this._modalListener) {
-				this.$frameParent.removeEventListener("focus", this._modalListener, true);  //$NON-NLS-0$
-				this.$frameParent.removeEventListener("click", this._modalListener, true);  //$NON-NLS-0$
-			}
-
-			this.$frame.classList.remove("dialogShowing"); //$NON-NLS-0$
-			lib.setFramesEnabled(true);
-			if (typeof this._afterHiding === "function") { //$NON-NLS-0$
-				this._afterHiding();
-			}
-			if (hasFocus && originalFocus && document.compareDocumentPosition(originalFocus) !== 1) {
-				originalFocus.focus();
-			}
+			lib.returnFocus(this.$frameParent, this.$originalFocus, function() {
+				if(!keepCurrentModal && modalDialogManager.dialog === this) {
+					modalDialogManager.dialog = null;
+				}
+				if (typeof this._beforeHiding === "function") { //$NON-NLS-0$
+					this._beforeHiding();
+				}
+				if (this._modalListener) {
+					this.$frameParent.removeEventListener("focus", this._modalListener, true);  //$NON-NLS-0$
+					this.$frameParent.removeEventListener("click", this._modalListener, true);  //$NON-NLS-0$
+				}
+	
+				this.$frame.classList.remove("dialogShowing"); //$NON-NLS-0$
+				lib.setFramesEnabled(true);
+				if (typeof this._afterHiding === "function") { //$NON-NLS-0$
+					this._afterHiding();
+				}
+			}.bind(this));
 			var self = this;
 			if (!this.keepAlive) {
 				window.setTimeout(function() { self.destroy(); }, 0);

--- a/bundles/org.eclipse.orion.client.ui/web/orion/webui/littlelib.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/webui/littlelib.js
@@ -477,7 +477,7 @@ define(["orion/util"], function(util) {
 	/**
 	 * Return focus to the element that was active before the <code>hidingParent</code> was
 	 * shown if the parent contains the active element. If the previous active node is no
-	 * longer availble, the first tabbable ancestor is focused.
+	 * longer available, the first tabbable in the nearest ancestor is focused.
 	 * 
 	 * @name orion.webui.littlelib.returnFocus
 	 * @function

--- a/bundles/org.eclipse.orion.client.ui/web/orion/webui/littlelib.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/webui/littlelib.js
@@ -475,6 +475,43 @@ define(["orion/util"], function(util) {
 	}
 	
 	/**
+	 * Return focus to the element that was active before the <code>hidingParent</code> was
+	 * shown if the parent contains the active element. If the previous active node is no
+	 * longer availble, the first tabbable ancestor is focused.
+	 * 
+	 * @name orion.webui.littlelib.returnFocus
+	 * @function
+	 * @static
+	 * @param {Element} hidingParent The node that is hiding
+	 * @param {Element} previousActiveElement The previously focus node
+	 */
+	function returnFocus(hidingParent, previousActiveElement, hideCallback) {
+		var activeElement = document.activeElement;
+		var hasFocus = hidingParent && (hidingParent === activeElement || (hidingParent.compareDocumentPosition(activeElement) & 16) !== 0);
+		if (hideCallback) {
+			hideCallback();
+		}
+		var temp = previousActiveElement;
+		if (hasFocus) {
+			while (temp && temp !== document.body) {
+				if (document.compareDocumentPosition(temp) !== 1 && temp.offsetParent) {
+					var tabbable = firstTabbable(temp);
+					if (tabbable) {
+						temp = tabbable;
+						break;
+					}
+				}
+				temp = temp.parentNode;
+			}
+			if (temp) {
+				temp.focus();
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
 	 * Cancels the default behavior of an event and stops its propagation.
 	 * @name orion.webui.littlelib.stop
 	 * @function
@@ -579,6 +616,7 @@ define(["orion/util"], function(util) {
 		validId: validId,
 		getOffsetParent: getOffsetParent,
 		removeAutoDismiss: removeAutoDismiss,
+		returnFocus: returnFocus,
 		keyName: keyName,
 		KEY: KEY,
 		createNodes: createNodes


### PR DESCRIPTION
Fixes

- Focus move to the begining of the page after exit "compare with.." panel
- Focus move to an invisible place between project tree and editor after exit "search" or "show problems"