### PR TITLE
BCD & DI AVT - Low contrast for some text in some page org-ids/web-ide-issues#788

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/css/progress.css
+++ b/bundles/org.eclipse.orion.client.ui/web/css/progress.css
@@ -9,7 +9,7 @@
 
 .progressInfo {
 	color: white !important;
-	background-color: #5aaafa !important;
+	background-color: #3C71B3 !important;
 }
 
 /* More prominent hyperlinks in notification area */

--- a/bundles/org.eclipse.orion.client.ui/web/css/progress.css
+++ b/bundles/org.eclipse.orion.client.ui/web/css/progress.css
@@ -263,7 +263,7 @@
 
 .notificationShow {
 	color: white; 
-	background-color: #1BB199; 
+	background-color: #458500; 
 	bottom: 0;
 	position: fixed;
 	float: left; 
@@ -290,7 +290,7 @@
 }
 .notificationHide {
 	color: white; 
-	background-color: #1BB199; 
+	background-color: #458500; 
 	bottom: -45px;
 	position: fixed;
 	text-align:center;


### PR DESCRIPTION
Fixes a couple more contrast problems in the notifications background.