### PR TITLE
Focus does not return to menu after closing tooltip

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/webui/littlelib.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/webui/littlelib.js
@@ -180,8 +180,9 @@ define(["orion/util"], function(util) {
 	/* 
 	 * Inspired by http://brianwhitmer.blogspot.com/2009/05/jquery-ui-tabbable-what.html
 	 */
-	function firstTabbable(node) {
-		if (_getTabIndex(node) >= 0 && !node.disabled && node.offsetParent) {
+	function firstTabbable(node, allowFocusable) {
+		var tabIndex = _getTabIndex(node);
+		if ((tabIndex >= 0 || allowFocusable && tabIndex >= -1) && !node.disabled && node.offsetParent) {
 			return node;
 		}
 		if (node.hasChildNodes()) {
@@ -495,7 +496,7 @@ define(["orion/util"], function(util) {
 		if (hasFocus) {
 			while (temp && temp !== document.body) {
 				if (document.compareDocumentPosition(temp) !== 1 && temp.offsetParent) {
-					var tabbable = firstTabbable(temp);
+					var tabbable = firstTabbable(temp, previousActiveElement === temp);
 					if (tabbable) {
 						temp = tabbable;
 						break;


### PR DESCRIPTION
1) Select any file in Navigator
2) Shift+F10 to open context menu
3) Down arrow (New)
4) Right arrow (File)
5) Shift+F1 to open tooltip
6) Esc to close tooltip
7) Focus is up on Filesystem button?