### PR TITLE
Fix focus trap in hidden slideout. Steps:

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/webui/Slideout.css
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/webui/Slideout.css
@@ -27,7 +27,7 @@ html[dir="rtl"] .slideoutWrapper { /* BDL */
 }
 
 .slideoutNoVisibility {
-	visibility: hidden !important; /* this class is separate because it is applied after the transition duration */
+	display: none; /* this class is separate because it is applied after the transition duration */
 }
 
 .slideoutWrapper > .slideoutDismissButton {

--- a/bundles/org.eclipse.orion.client.ui/web/orion/webui/Slideout.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/webui/Slideout.js
@@ -115,7 +115,10 @@ define([
 			this._wrapperNode.classList.remove("slideoutNoVisibility"); //$NON-NLS-0$
 			
 			// step 2: add CSS class to position slideout within visible range
-			this._wrapperNode.classList.add("slideoutWrapperVisible"); //$NON-NLS-0$
+			// done in a timeout for the trasition animation to work
+			setTimeout(function() {
+				this._wrapperNode.classList.add("slideoutWrapperVisible"); //$NON-NLS-0$
+			}.bind(this), 0);
 		},
 		
 		/**


### PR DESCRIPTION
1) Open the editor page
2) Open a file
3) Open the search panel by type its shortcut (Cmd+Shift+H on mac)
4) Hide the panel by typing Esc
5) Change the tab mode to exit the editor
6) Shift+Tab  to reach the navigator

Focus will reach the hidden slideout and stay trapped in there