### PR TITLE
CD & DI AVT - The combobox attribute 'aria-haspopup' value must be appropriate for the role of the element referenced by 'aria-controls'

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/inputCompletion/inputCompletion.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/inputCompletion/inputCompletion.js
@@ -138,7 +138,7 @@ define(['orion/EventTarget', 'orion/bidiUtils', 'orion/urlModifier', 'orion/webu
 		lib.setSafeAttribute(this._inputField, "role", "combobox");
 		lib.setSafeAttribute(this._inputField, "autocomplete", "off");
 		lib.setSafeAttribute(this._inputField, "aria-autocomplete", "list");
-		lib.setSafeAttribute(this._inputField, "aria-haspopup", true);
+		lib.setSafeAttribute(this._inputField, "aria-haspopup", "listbox");
 		lib.setSafeAttribute(this._inputField, "aria-expanded", false);
 		
 		var blurHanlder = function(e) {


### PR DESCRIPTION
https://github.ibm.com/org-ids/web-ide-issues/issues/1857